### PR TITLE
Fixed unit tests after the HTTP Server code was removed from `bluesky-queueserver` repository

### DIFF
--- a/bluesky_httpserver/server/tests/conftest.py
+++ b/bluesky_httpserver/server/tests/conftest.py
@@ -3,7 +3,7 @@ from xprocess import ProcessStarter
 import time as ttime
 import requests
 
-import bluesky_queueserver.server.server as bqss
+import bluesky_httpserver.server.server as bqss
 from bluesky_queueserver.manager.comms import zmq_single_request
 
 SERVER_ADDRESS = "localhost"

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -13,7 +13,7 @@ from bluesky_queueserver.manager.tests.common import (  # noqa F401
     append_code_to_last_startup_file,
 )
 
-from bluesky_queueserver.server.tests.conftest import (  # noqa F401
+from bluesky_httpserver.server.tests.conftest import (  # noqa F401
     SERVER_ADDRESS,
     SERVER_PORT,
     add_plans_to_queue,

--- a/bluesky_httpserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_httpserver/server/tests/test_http_server_func_scope.py
@@ -14,7 +14,7 @@ from bluesky_queueserver.manager.tests.common import (  # noqa F401
     set_qserver_zmq_address,
 )
 
-from bluesky_queueserver.server.tests.conftest import (  # noqa F401
+from bluesky_httpserver.server.tests.conftest import (  # noqa F401
     SERVER_ADDRESS,
     SERVER_PORT,
     add_plans_to_queue,

--- a/bluesky_httpserver/server/tests/test_server.py
+++ b/bluesky_httpserver/server/tests/test_server.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bluesky_queueserver.server.server import validate_payload_keys
+from bluesky_httpserver.server.server import validate_payload_keys
 
 
 # fmt: off


### PR DESCRIPTION
Minor changes to unit test code that fix issues unit tests that were discovered after the server code was removed from `bluesky-queueserver` repository.