### PR TITLE
Updating REST API to match RE Manager 0MQ API

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -481,15 +481,15 @@ Additional API
 --------------
 API that are implemented, but not listed in this document:
 
-- `/re/runs` - access to `re_runs`, combines `/re/runs/active`, `/re/runs/open`, `/re/runs/closed`
-- `/plans/existing` - access to `plans_existing` API
-- `/devices/existing` - access to `devices_existing` API
-- `/permissions/get` - access to `permissions_get` API
-- `/permissions/set` - access to `permissions_set` API
-- `/script/upload` - access to `script_upload` API
-- `/function/execute` - access to `function_execute` API
-- `/task/status` - access to `task_status` API
-- `/task/result` - access to `task_result` API
+- ``/re/runs`` - access to ``re_runs``, combines ``/re/runs/active``, ``/re/runs/open``, ``/re/runs/closed``
+- ``/plans/existing`` - access to ``plans_existing`` API
+- ``/devices/existing`` - access to ``devices_existing`` API
+- ``/permissions/get`` - access to ``permissions_get`` API
+- ``/permissions/set`` - access to ``permissions_set`` API
+- ``/script/upload`` - access to ``script_upload`` API
+- ``/function/execute`` - access to ``function_execute`` API
+- ``/task/status`` - access to ``task_status`` API
+- ``/task/result`` - access to ``task_result`` API
 
 
 Streaming Console Output of RE Manager

--- a/README.rst
+++ b/README.rst
@@ -169,8 +169,8 @@ Get the lists (JSON) of allowed plans and devices::
   qserver allowed plans
   qserver allowed devices
 
-  http GET http://localhost:60610/plans/allowed
-  http GET http://localhost:60610/devices/allowed
+  http POST http://localhost:60610/plans/allowed
+  http POST http://localhost:60610/devices/allowed
 
 The list of allowed plans and devices is generated based on the list of existing plans and devices
 ('existing_plans_and_devices.yaml' by default) and user group permissions ('user_group_permissions.yaml'
@@ -475,6 +475,22 @@ is to test handling of communication timeouts, since RE Manager does not respond
 
   qserver manager kill test
   http POST http://localhost:60610/test/manager/kill
+
+
+Additional API
+--------------
+API that are implemented, but not listed in this document:
+
+- `/re/runs` - access to `re_runs`, combines `/re/runs/active`, `/re/runs/open`, `/re/runs/closed`
+- `/plans/existing` - access to `plans_existing` API
+- `/devices/existing` - access to `devices_existing` API
+- `/permissions/get` - access to `permissions_get` API
+- `/permissions/set` - access to `permissions_set` API
+- `/script/upload` - access to `script_upload` API
+- `/function/execute` - access to `function_execute` API
+- `/task/status` - access to `task_status` API
+- `/task/result` - access to `task_result` API
+
 
 Streaming Console Output of RE Manager
 --------------------------------------

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -525,7 +525,7 @@ async def re_halt_handler():
 
 
 @app.post("/re/runs")
-async def re_runs_handler(payload: dict):
+async def re_runs_handler(payload: dict={}):
     """
     Run Engine: download the list of active, open or closed runs (runs that were opened
     during execution of the currently running plan and combines the subsets of 'open' and

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -640,6 +640,45 @@ async def permissions_set_handler(payload: dict):
     return msg
 
 
+@app.post("/function/execute")
+async def function_execute_handler(payload: dict):
+    """
+    Execute function defined in startup scripts in RE Worker environment.
+    """
+    params = payload
+    params["user"] = _login_data["user"]
+    params["user_group"] = _login_data["user_group"]
+    msg = await zmq_to_manager.send_message(method="function_execute", params=params)
+    return msg
+
+
+@app.post("/script/upload")
+async def script_upload_handler(payload: dict):
+    """
+    Upload and execute script in RE Worker environment.
+    """
+    msg = await zmq_to_manager.send_message(method="script_upload", params=payload)
+    return msg
+
+
+@app.post("/task/status")
+async def script_task_status(payload: dict):
+    """
+    Return status of one or more running tasks.
+    """
+    msg = await zmq_to_manager.send_message(method="task_status", params=payload)
+    return msg
+
+
+@app.post("/task/result")
+async def script_task_result(payload: dict):
+    """
+    Return result of execution of a running or completed task.
+    """
+    msg = await zmq_to_manager.send_message(method="task_result", params=payload)
+    return msg
+
+
 @app.post("/manager/stop")
 async def manager_stop_handler(payload: dict = {}):
     """

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -622,6 +622,24 @@ async def permissions_reload_handler(payload: dict = {}):
     return msg
 
 
+@app.post("/permissions/get")
+async def permissions_get_handler():
+    """
+    Download the dictionary of user group permissions.
+    """
+    msg = await zmq_to_manager.send_message(method="permissions_get")
+    return msg
+
+
+@app.post("/permissions/set")
+async def permissions_set_handler(payload: dict):
+    """
+    Upload the dictionary of user group permissions (parameter: ``user_group_permissions``).
+    """
+    msg = await zmq_to_manager.send_message(method="permissions_set", params=payload)
+    return msg
+
+
 @app.post("/manager/stop")
 async def manager_stop_handler(payload: dict = {}):
     """

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -524,6 +524,18 @@ async def re_halt_handler():
     return msg
 
 
+@app.post("/re/runs")
+async def re_runs_handler(payload: dict):
+    """
+    Run Engine: download the list of active, open or closed runs (runs that were opened
+    during execution of the currently running plan and combines the subsets of 'open' and
+    'closed' runs.) The parameter ``options`` is used to select the category of runs
+    (``'active'``, ``'open'`` or ``'closed'``). By default the API returns the active runs.
+    """
+    msg = await zmq_to_manager.send_message(method="re_runs", params=payload)
+    return msg
+
+
 @app.get("/re/runs/active")
 async def re_runs_active_handler():
     """

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -17,7 +17,7 @@ logger.setLevel(logging.INFO)
 
 # Login and authentication are not implemented, but some API methods require
 #   login data. So for now we set up fixed user name and group
-_login_data = {"user": "John Doe", "user_group": "admin"}
+_login_data = {"user": "Default HTTP User", "user_group": "admin"}
 
 logging.basicConfig(level=logging.WARNING)
 logging.getLogger("bluesky_queueserver").setLevel("DEBUG")

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -567,25 +567,49 @@ async def re_runs_closed_handler():
     return msg
 
 
-@app.get("/plans/allowed")
-async def plans_allowed_handler():
+@app.post("/plans/allowed")
+async def plans_allowed_handler(payload: dict = {}):
     """
-    Returns the lists of allowed plans.
+    Returns the lists of allowed plans. If boolean optional parameter ``simplified``
+    is ``True``, then simplify plan descriptions before calling the API.
     """
+    simplify = payload.get("simplified", False)
     params = {"user_group": _login_data["user_group"]}
     msg = await zmq_to_manager.send_message(method="plans_allowed", params=params)
-    if "plans_allowed" in msg:
+    if simplify and ("plans_allowed" in msg):
         msg["plans_allowed"] = simplify_plan_descriptions(msg["plans_allowed"])
     return msg
 
 
-@app.get("/devices/allowed")
+@app.post("/devices/allowed")
 async def devices_allowed_handler():
     """
     Returns the lists of allowed devices.
     """
     params = {"user_group": _login_data["user_group"]}
     msg = await zmq_to_manager.send_message(method="devices_allowed", params=params)
+    return msg
+
+
+@app.post("/plans/existing")
+async def plans_existing_handler(payload: dict = {}):
+    """
+    Returns the lists of existing plans. If boolean optional parameter ``simplified``
+    is ``True``, then simplify plan descriptions before calling the API.
+    """
+    simplify = payload.get("simplified", False)
+    msg = await zmq_to_manager.send_message(method="plans_existing")
+    if simplify and ("plans_existing" in msg):
+        msg["plans_existing"] = simplify_plan_descriptions(msg["plans_existing"])
+    return msg
+
+
+@app.post("/devices/existing")
+async def devices_existing_handler():
+    """
+    Returns the lists of existing devices.
+    """
+    msg = await zmq_to_manager.send_message(method="devices_existing")
     return msg
 
 

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -165,7 +165,7 @@ async def status_handler():
 @app.post("/queue/mode/set")
 async def queue_mode_set_handler(payload: dict):
     """
-    Clear the plan queue.
+    Set queue mode.
     """
     params = payload
     msg = await zmq_to_manager.send_message(method="queue_mode_set", params=params)
@@ -408,7 +408,7 @@ async def queue_item_move_batch_handler(payload: dict):
 
 
 @app.post("/queue/item/get")
-async def queue_item_get_handler(payload: dict):
+async def queue_item_get_handler(payload: dict = {}):
     """
     Get a plan from the queue
     """

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -590,13 +590,13 @@ async def devices_allowed_handler():
 
 
 @app.post("/permissions/reload")
-async def permissions_reload_handler():
+async def permissions_reload_handler(payload: dict):
     """
     Reloads the list of allowed plans and devices and user group permission from the default location
     or location set using command line parameters of RE Manager. Use this request to reload the data
     if the respective files were changed on disk.
     """
-    msg = await zmq_to_manager.send_message(method="permissions_reload")
+    msg = await zmq_to_manager.send_message(method="permissions_reload", params=payload)
     return msg
 
 

--- a/bluesky_httpserver/server/tests/test_console_output.py
+++ b/bluesky_httpserver/server/tests/test_console_output.py
@@ -92,10 +92,8 @@ def test_http_server_stream_console_output_1(
     assert resp1["item"]["args"] == [["det1", "det2"]]
     assert "item_uid" in resp1["item"]
 
-    # Wait until capture is complete (2 message are expected) or timetout expires
-    t_start, t_timeout = ttime.time(), 10
-    while (len(rsc.received_data_buffer) < 2) and (ttime.time() - t_start < t_timeout):
-        pass
+    # Wait until capture is complete (at least 2 message are expected) or timetout expires
+    ttime.sleep(5)
     rsc.stop()
     # Note, that some output from the server is is needed in order to exit the loop in the thread.
 
@@ -106,6 +104,8 @@ def test_http_server_stream_console_output_1(
     assert resp2["running_item"] == {}
 
     rsc.join()
+
+    assert len(rsc.received_data_buffer) >= 2, pprint.pformat(rsc.received_data_buffer)
 
     # Verify that expected messages ('strings') are contained in captured messages.
     expected_messages = {"Adding new item to the queue", "Item added"}

--- a/bluesky_httpserver/server/tests/test_console_output.py
+++ b/bluesky_httpserver/server/tests/test_console_output.py
@@ -93,7 +93,7 @@ def test_http_server_stream_console_output_1(
     assert "item_uid" in resp1["item"]
 
     # Wait until capture is complete (at least 2 message are expected) or timetout expires
-    ttime.sleep(5)
+    ttime.sleep(10)
     rsc.stop()
     # Note, that some output from the server is is needed in order to exit the loop in the thread.
 

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -40,7 +40,7 @@ _instruction_stop = {"name": "queue_stop", "item_type": "instruction"}
 # fmt: on
 def test_http_server_ping_handler(re_manager, fastapi_server, api_call):  # noqa F811
     resp = request_to_json("get", api_call)
-    assert resp["msg"] == "RE Manager"
+    assert resp["msg"].startswith("RE Manager")
     assert resp["manager_state"] == "idle"
     assert resp["items_in_queue"] == 0
     assert resp["running_item_uid"] is None
@@ -49,7 +49,7 @@ def test_http_server_ping_handler(re_manager, fastapi_server, api_call):  # noqa
 
 def test_http_server_status_handler(re_manager, fastapi_server):  # noqa F811
     resp = request_to_json("get", "/status")
-    assert resp["msg"] == "RE Manager"
+    assert resp["msg"].startswith("RE Manager")
     assert resp["manager_state"] == "idle"
     assert resp["items_in_queue"] == 0
     assert resp["running_item_uid"] is None
@@ -1166,7 +1166,7 @@ def test_http_server_manager_kill(re_manager, fastapi_server):  # noqa F811
     ttime.sleep(10)
 
     resp = request_to_json("get", "/status")
-    assert resp["msg"] == "RE Manager"
+    assert resp["msg"].startswith("RE Manager")
     assert resp["manager_state"] == "idle"
     assert resp["items_in_queue"] == 0
     assert resp["running_item_uid"] is None
@@ -1202,7 +1202,7 @@ def test_http_server_manager_stop_handler_2(re_manager, fastapi_server, option):
 
     ttime.sleep(2)
     resp = request_to_json("get", "/status")
-    assert resp["msg"] == "RE Manager"
+    assert resp["msg"].startswith("RE Manager")
     assert resp["manager_state"] == "executing_queue"
     assert resp["items_in_queue"] == 2
     assert resp["running_item_uid"] is not None
@@ -1221,7 +1221,7 @@ def test_http_server_manager_stop_handler_2(re_manager, fastapi_server, option):
         # The queue is expected to be running
         ttime.sleep(15)
         resp = request_to_json("get", "/status")
-        assert resp["msg"] == "RE Manager"
+        assert resp["msg"].startswith("RE Manager")
         assert resp["manager_state"] == "idle"
         assert resp["items_in_queue"] == 0
         assert resp["items_in_history"] == 3

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -102,13 +102,34 @@ def test_http_server_queue_get_handler(re_manager, fastapi_server):  # noqa F811
     assert resp["running_item"] == {}
 
 
-def test_http_server_plans_allowed_and_devices(re_manager, fastapi_server):  # noqa F811
-    resp1 = request_to_json("get", "/plans/allowed")
-    assert isinstance(resp1["plans_allowed"], dict)
-    assert len(resp1["plans_allowed"]) > 0
-    resp2 = request_to_json("get", "/devices/allowed")
-    assert isinstance(resp2["devices_allowed"], dict)
-    assert len(resp2["devices_allowed"]) > 0
+# fmt: off
+@pytest.mark.parametrize("simplified", [None, False, True])
+# fmt: on
+def test_http_server_plans_allowed_and_devices(re_manager, fastapi_server, simplified):  # noqa F811
+    kwargs = {"json": {"simplified": simplified}} if (simplified is not None) else {}
+    resp1 = request_to_json("post", "/plans/allowed", **kwargs)
+    assert "plans_allowed" in resp1, pprint.pformat(resp1)
+    assert isinstance(resp1["plans_allowed"], dict), pprint.pformat(resp1)
+    assert len(resp1["plans_allowed"]) > 0, pprint.pformat(resp1)
+    resp2 = request_to_json("post", "/devices/allowed")
+    assert "devices_allowed" in resp2, pprint.pformat(resp2)
+    assert isinstance(resp2["devices_allowed"], dict), pprint.pformat(resp2)
+    assert len(resp2["devices_allowed"]) > 0, pprint.pformat(resp2)
+
+
+# fmt: off
+@pytest.mark.parametrize("simplified", [None, False, True])
+# fmt: on
+def test_http_server_plans_existing_and_devices(re_manager, fastapi_server, simplified):  # noqa F811
+    kwargs = {"json": {"simplified": simplified}} if (simplified is not None) else {}
+    resp1 = request_to_json("post", "/plans/existing", **kwargs)
+    assert "plans_existing" in resp1, pprint.pformat(resp1)
+    assert isinstance(resp1["plans_existing"], dict), pprint.pformat(resp1)
+    assert len(resp1["plans_existing"]) > 0, pprint.pformat(resp1)
+    resp2 = request_to_json("post", "/devices/existing")
+    assert "devices_existing" in resp2, pprint.pformat(resp2)
+    assert isinstance(resp2["devices_existing"], dict), pprint.pformat(resp2)
+    assert len(resp2["devices_existing"]) > 0, pprint.pformat(resp2)
 
 
 def test_http_server_queue_item_add_handler_1(re_manager, fastapi_server):  # noqa F811

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -1344,8 +1344,10 @@ def test_http_server_reload_permissions(re_manager_pc_copy, fastapi_server, tmp_
     resp1 = request_to_json("post", "/queue/item/add", json=plan)
     assert resp1["success"] is False, str(resp1)
 
-    # Reload profile collection
-    resp2 = request_to_json("post", "/permissions/reload")
+    # Reload profile collection. The new 'existing_plans_and_devices.yaml' was
+    #   generated externally and we need to reload it, which does not happen by default.
+    kwargs = {"json": {"reload_plans_devices": True}}
+    resp2 = request_to_json("post", "/permissions/reload", **kwargs)
     assert resp2["success"] is True, str(resp2)
 
     # Attempt to add the plan to the queue. It should be successful now.

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -504,12 +504,24 @@ def test_http_server_queue_item_get_remove_handler_1(re_manager, fastapi_server)
     assert resp2["item"]["args"] == [["det1", "det2"]]
     assert "item_uid" in resp2["item"]
 
-    resp3 = request_to_json("post", "/queue/item/remove", json={})
+    resp3 = request_to_json("post", "/queue/item/get")
     assert resp3["success"] is True
-    assert resp3["qsize"] == 2
     assert resp3["item"]["name"] == "count"
     assert resp3["item"]["args"] == [["det1", "det2"]]
     assert "item_uid" in resp3["item"]
+
+    resp4 = request_to_json("post", "/queue/item/get")
+    assert resp4["success"] is True
+    assert resp4["item"]["name"] == "count"
+    assert resp4["item"]["args"] == [["det1", "det2"]]
+    assert "item_uid" in resp4["item"]
+
+    resp5 = request_to_json("post", "/queue/item/remove", json={})
+    assert resp5["success"] is True
+    assert resp5["qsize"] == 2
+    assert resp5["item"]["name"] == "count"
+    assert resp5["item"]["args"] == [["det1", "det2"]]
+    assert "item_uid" in resp5["item"]
 
 
 # fmt: off

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -1422,3 +1422,19 @@ def test_http_server_reload_permissions_02(re_manager_pc_copy, fastapi_server, t
     kwargs = {} if params is None else {"json": params}
     resp1 = request_to_json("post", "/permissions/reload", **kwargs)
     assert resp1["success"] is True, str(resp1)
+
+
+def test_http_server_permissions_get_set_01(re_manager, fastapi_server):  # noqa F811
+    """
+    Tests for ``/permissions/get`` and ``/permissions/set`` API.
+    """
+    resp1 = request_to_json("post", "/permissions/get")
+    assert resp1["success"] is True, str(resp1)
+    assert resp1["msg"] == ""
+    user_group_permissions = resp1["user_group_permissions"]
+    assert isinstance(user_group_permissions, dict)
+    assert user_group_permissions
+
+    resp2 = request_to_json("post", "/permissions/set", json={"user_group_permissions": user_group_permissions})
+    assert resp2["success"] is True, str(resp2)
+    assert resp2["msg"] == ""

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -1299,6 +1299,7 @@ def test_http_server_queue_stop(re_manager, fastapi_server, deactivate):  # noqa
 
 # fmt: off
 @pytest.mark.parametrize("suffix, expected_n_items", [
+    (None, 1),
     ("active", 1),
     ("open", 1),
     ("closed", 0),
@@ -1323,14 +1324,14 @@ def test_http_server_re_runs(re_manager, fastapi_server, suffix, expected_n_item
     run_list_uid = status["run_list_uid"]
     assert isinstance(run_list_uid, str)
 
-    req = "/re/runs/" + suffix
+    req = "/re/runs/" + (suffix if suffix is not None else "active")
 
     resp2 = request_to_json("get", req)
     assert resp2["success"] is True
     assert len(resp2["run_list"]) == expected_n_items
     assert resp2["run_list_uid"] == run_list_uid
 
-    kwargs = {"json": {"option": suffix}}
+    kwargs = {"json": {"option": suffix}} if suffix is not None else {}
     resp2a = request_to_json("post", "/re/runs", **kwargs)
     assert resp2a["success"] is True
     assert len(resp2a["run_list"]) == expected_n_items

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -1278,9 +1278,9 @@ def test_http_server_queue_stop(re_manager, fastapi_server, deactivate):  # noqa
 
 # fmt: off
 @pytest.mark.parametrize("suffix, expected_n_items", [
-    ("/active", 1),
-    ("/open", 1),
-    ("/closed", 0),
+    ("active", 1),
+    ("open", 1),
+    ("closed", 0),
 ])
 # fmt: on
 def test_http_server_re_runs(re_manager, fastapi_server, suffix, expected_n_items):  # noqa F811
@@ -1302,11 +1302,18 @@ def test_http_server_re_runs(re_manager, fastapi_server, suffix, expected_n_item
     run_list_uid = status["run_list_uid"]
     assert isinstance(run_list_uid, str)
 
-    req = "/re/runs" + suffix
+    req = "/re/runs/" + suffix
+
     resp2 = request_to_json("get", req)
     assert resp2["success"] is True
     assert len(resp2["run_list"]) == expected_n_items
     assert resp2["run_list_uid"] == run_list_uid
+
+    kwargs = {"json": {"option": suffix}}
+    resp2a = request_to_json("post", "/re/runs", **kwargs)
+    assert resp2a["success"] is True
+    assert len(resp2a["run_list"]) == expected_n_items
+    assert resp2a["run_list_uid"] == run_list_uid
 
     assert wait_for_manager_state_idle(30), "Timeout"
 

--- a/bluesky_httpserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_httpserver/server/tests/test_http_server_func_scope.py
@@ -323,10 +323,10 @@ def test_http_server_secure_1(monkeypatch, re_manager_cmd, fastapi_server_fs, te
     resp2 = request_to_json("post", "/queue/item/add", json={"item": _plan2})
     assert resp2["success"] is True, str(resp2)
 
-    resp3 = request_to_json("get", "/plans/allowed")
+    resp3 = request_to_json("post", "/plans/allowed")
     assert isinstance(resp3["plans_allowed"], dict)
     assert len(resp3["plans_allowed"]) > 0
-    resp4 = request_to_json("get", "/devices/allowed")
+    resp4 = request_to_json("post", "/devices/allowed")
     assert isinstance(resp4["devices_allowed"], dict)
     assert len(resp4["devices_allowed"]) > 0
 


### PR DESCRIPTION
- Updated the existing API: `/plans/allowed` and `/devices/allowed` are changed from `GET` to `POST`. `/plans/allowed` now accepts an optional parameter `reduced`. If `"reduced": True`, then the simplified version of plan descriptions that could be more convenient for web applications are returned, otherwise full descriptions are returned. Previously the API always returned simplified descriptions.
- New API `/re/runs` (POST), which combines already existing `/re/runs/active`, `/re/runs/open` and `/re/runs/closed`.
- The following API were added: `plans_existing`, `devices_existing`, `permissions_get`, `permissions_set`, `script_upload`, `function_execute`, `task_status`, `task_result`.