### PR TITLE
Placeholder for non-streaming '/console_output' endpoint

### DIFF
--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -551,7 +551,7 @@ async def re_runs_closed_handler():
     return msg
 
 
-@app.post("/plans/allowed")
+@app.get("/plans/allowed")
 async def plans_allowed_handler(payload: dict = {}):
     """
     Returns the lists of allowed plans. If boolean optional parameter ``reduced``
@@ -573,7 +573,7 @@ async def plans_allowed_handler(payload: dict = {}):
     return msg
 
 
-@app.post("/devices/allowed")
+@app.get("/devices/allowed")
 async def devices_allowed_handler():
     """
     Returns the lists of allowed devices.
@@ -583,7 +583,7 @@ async def devices_allowed_handler():
     return msg
 
 
-@app.post("/plans/existing")
+@app.get("/plans/existing")
 async def plans_existing_handler(payload: dict = {}):
     """
     Returns the lists of existing plans. If boolean optional parameter ``reduced``
@@ -602,7 +602,7 @@ async def plans_existing_handler(payload: dict = {}):
     return msg
 
 
-@app.post("/devices/existing")
+@app.get("/devices/existing")
 async def devices_existing_handler():
     """
     Returns the lists of existing devices.
@@ -704,3 +704,9 @@ def stream_console_output():
     stm = ConsoleOutputEventStream(queues_set=queues_set)
     sr = StreamingResponseFromClass(stm, media_type="text/plain")
     return sr
+
+@app.get("/console_output")
+def stream_console_output(payload: dict):
+    n_lines = payload.get("lines", 200)
+    text = "Some output"
+    return text

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -707,7 +707,7 @@ def stream_console_output():
 
 
 @app.get("/console_output")
-def console_output(payload: dict):
+def console_output(payload: dict = {}):
     n_lines = payload.get("lines", 200)
     text = "Console output ...\n" * n_lines
     return text

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -705,8 +705,9 @@ def stream_console_output():
     sr = StreamingResponseFromClass(stm, media_type="text/plain")
     return sr
 
+
 @app.get("/console_output")
-def stream_console_output(payload: dict):
+def console_output(payload: dict):
     n_lines = payload.get("lines", 200)
-    text = "Some output"
+    text = "Console output ...\n" * n_lines
     return text

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -107,11 +107,11 @@ def test_http_server_queue_get_handler(re_manager, fastapi_server):  # noqa F811
 # fmt: on
 def test_http_server_plans_allowed_and_devices_01(re_manager, fastapi_server, reduced):  # noqa F811
     kwargs = {"json": {"reduced": reduced}} if (reduced is not None) else {}
-    resp1 = request_to_json("post", "/plans/allowed", **kwargs)
+    resp1 = request_to_json("get", "/plans/allowed", **kwargs)
     assert "plans_allowed" in resp1, pprint.pformat(resp1)
     assert isinstance(resp1["plans_allowed"], dict), pprint.pformat(resp1)
     assert len(resp1["plans_allowed"]) > 0, pprint.pformat(resp1)
-    resp2 = request_to_json("post", "/devices/allowed")
+    resp2 = request_to_json("get", "/devices/allowed")
     assert "devices_allowed" in resp2, pprint.pformat(resp2)
     assert isinstance(resp2["devices_allowed"], dict), pprint.pformat(resp2)
     assert len(resp2["devices_allowed"]) > 0, pprint.pformat(resp2)
@@ -119,7 +119,7 @@ def test_http_server_plans_allowed_and_devices_01(re_manager, fastapi_server, re
 
 def test_http_server_plans_allowed_and_devices_02(re_manager, fastapi_server):  # noqa F811
     kwargs = {"json": {"unsupported": False}}
-    resp1 = request_to_json("post", "/plans/allowed", **kwargs)
+    resp1 = request_to_json("get", "/plans/allowed", **kwargs)
     assert "detail" in resp1, pprint.pformat(resp1)
     assert "Request contains keys the are not supported: {'unsupported'}" in resp1["detail"]
 
@@ -129,11 +129,11 @@ def test_http_server_plans_allowed_and_devices_02(re_manager, fastapi_server):  
 # fmt: on
 def test_http_server_plans_existing_and_devices_01(re_manager, fastapi_server, reduced):  # noqa F811
     kwargs = {"json": {"reduced": reduced}} if (reduced is not None) else {}
-    resp1 = request_to_json("post", "/plans/existing", **kwargs)
+    resp1 = request_to_json("get", "/plans/existing", **kwargs)
     assert "plans_existing" in resp1, pprint.pformat(resp1)
     assert isinstance(resp1["plans_existing"], dict), pprint.pformat(resp1)
     assert len(resp1["plans_existing"]) > 0, pprint.pformat(resp1)
-    resp2 = request_to_json("post", "/devices/existing")
+    resp2 = request_to_json("get", "/devices/existing")
     assert "devices_existing" in resp2, pprint.pformat(resp2)
     assert isinstance(resp2["devices_existing"], dict), pprint.pformat(resp2)
     assert len(resp2["devices_existing"]) > 0, pprint.pformat(resp2)
@@ -141,7 +141,7 @@ def test_http_server_plans_existing_and_devices_01(re_manager, fastapi_server, r
 
 def test_http_server_plans_existing_and_devices_02(re_manager, fastapi_server):  # noqa F811
     kwargs = {"json": {"unsupported": False}}
-    resp1 = request_to_json("post", "/plans/existing", **kwargs)
+    resp1 = request_to_json("get", "/plans/existing", **kwargs)
     assert "detail" in resp1, pprint.pformat(resp1)
     assert "Request contains keys the are not supported: {'unsupported'}" in resp1["detail"]
 

--- a/bluesky_httpserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_httpserver/server/tests/test_http_server_func_scope.py
@@ -323,10 +323,10 @@ def test_http_server_secure_1(monkeypatch, re_manager_cmd, fastapi_server_fs, te
     resp2 = request_to_json("post", "/queue/item/add", json={"item": _plan2})
     assert resp2["success"] is True, str(resp2)
 
-    resp3 = request_to_json("post", "/plans/allowed")
+    resp3 = request_to_json("get", "/plans/allowed")
     assert isinstance(resp3["plans_allowed"], dict)
     assert len(resp3["plans_allowed"]) > 0
-    resp4 = request_to_json("post", "/devices/allowed")
+    resp4 = request_to_json("get", "/devices/allowed")
     assert isinstance(resp4["devices_allowed"], dict)
     assert len(resp4["devices_allowed"]) > 0
 


### PR DESCRIPTION
Changes:

- Created placeholder for `/console_output` placeholder, which accepts the parameter `lines` specifyng the number of lines to return.

- Changed endpoints `/plans/allowed`, `/devices/allowed`, `/plans/existing` and `/devices/existing` back to `GET`.