### PR TITLE
ENH: simple implementation of /console_output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -525,3 +525,14 @@ default or HTTP server is running on a separate workstation/server, the address 
 can be specified by setting the environment variable ``QSERVER_ZMQ_ADDRESS_CONSOLE``, e.g. ::
 
   export QSERVER_ZMQ_ADDRESS_CONSOLE='tcp://localhost:60625'
+
+
+Console Output of RE Manager
+----------------------------
+In some cases, using streaming console output is inconvenient or difficult. The server
+provides endpoint ``/console_output`` returns the last ``nlines`` of the console output
+represented as a text string. The parameter ``nlines`` is optional with the default value of 200.
+The maximum number of returned lines is limited (currently to 2000 lines). ::
+
+  http GET http://localhost:60610/console_output
+  http GET http://localhost:60610/console_output lines=500

--- a/bluesky_httpserver/server/console_output.py
+++ b/bluesky_httpserver/server/console_output.py
@@ -69,6 +69,10 @@ class CollectPublishedConsoleOutput:
 
         self._text_buffer.extend(line_list)
 
+        # Remove extra lines
+        while len(self._text_buffer) > self._text_buffer_max:
+            self._text_buffer.pop(0)
+
     def _add_message(self, msg):
         try:
             for q in self._queues_set.copy():

--- a/bluesky_httpserver/server/console_output.py
+++ b/bluesky_httpserver/server/console_output.py
@@ -51,7 +51,6 @@ class CollectPublishedConsoleOutput:
         """
         return self._queues_set
 
-    @property
     def get_text_buffer(self, n_lines):
         return "".join(self._text_buffer[-n_lines:])
 

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -710,5 +710,5 @@ def stream_console_output():
 def console_output(payload: dict = {}):
     n_lines = payload.get("lines", 200)
     text = console_output_loader.get_text_buffer(n_lines)
-    # text = "Console output ...\n" * n_lines
-    return text
+    # Add 'success' and 'msg' so that the API is compatible with other QServer API.
+    return {"success": True, "msg": "", "text": text}

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -709,5 +709,6 @@ def stream_console_output():
 @app.get("/console_output")
 def console_output(payload: dict = {}):
     n_lines = payload.get("lines", 200)
-    text = "Console output ...\n" * n_lines
+    text = console_output_loader.get_text_buffer(n_lines)
+    # text = "Console output ...\n" * n_lines
     return text

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -708,7 +708,7 @@ def stream_console_output():
 
 @app.get("/console_output")
 def console_output(payload: dict = {}):
-    n_lines = payload.get("lines", 200)
+    n_lines = payload.get("nlines", 200)
     text = console_output_loader.get_text_buffer(n_lines)
     # Add 'success' and 'msg' so that the API is compatible with other QServer API.
     return {"success": True, "msg": "", "text": text}

--- a/bluesky_httpserver/server/tests/test_console_output.py
+++ b/bluesky_httpserver/server/tests/test_console_output.py
@@ -186,7 +186,7 @@ def test_http_server_console_output_1(monkeypatch, re_manager_cmd, fastapi_serve
 
     assert expected_output in console_output
 
-    resp3b = request_to_json("get", "/console_output", json={"lines": 300})
+    resp3b = request_to_json("get", "/console_output", json={"nlines": 300})
     assert resp3b["success"] is True
     console_output = resp3b["text"]
 

--- a/bluesky_httpserver/server/tests/test_http_server.py
+++ b/bluesky_httpserver/server/tests/test_http_server.py
@@ -1397,7 +1397,7 @@ def test_http_server_reload_permissions_01(re_manager_pc_copy, fastapi_server, t
 
     # Reload profile collection. The new 'existing_plans_and_devices.yaml' was
     #   generated externally and we need to reload it, which does not happen by default.
-    kwargs = {"json": {"reload_plans_devices": True}}
+    kwargs = {"json": {"restore_plans_devices": True}}
     resp2 = request_to_json("post", "/permissions/reload", **kwargs)
     assert resp2["success"] is True, str(resp2)
 
@@ -1410,10 +1410,10 @@ def test_http_server_reload_permissions_01(re_manager_pc_copy, fastapi_server, t
 # fmt: off
 @pytest.mark.parametrize("params", [
     None,
-    {"reload_plans_devices": False},
-    {"reload_plans_devices": True},
-    {"reload_permissions": False},
-    {"reload_permissions": True},
+    {"restore_plans_devices": False},
+    {"restore_plans_devices": True},
+    {"restore_permissions": False},
+    {"restore_permissions": True},
 ])
 # fmt: on
 def test_http_server_reload_permissions_02(re_manager_pc_copy, fastapi_server, tmp_path, params):  # noqa F811


### PR DESCRIPTION
Simplistic implementation of the `/console_output` API. The API accepts optional parameter `nlines`, which defines the number of lines to return. The returned value is structured similarly to other Queue Server API:

```
{
    "success": True,
    "msg": "",
    "text": <payload - console output represented as multiline text string>,
} 
```