### PR TITLE
New endpoint: 'console_output_update'

### DIFF
--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -892,8 +892,36 @@ def console_output(payload: dict = {}):
 
 @app.get("/console_output/uid")
 def console_output_uid():
+    """
+    UID of the text buffer. Use with ``console_output`` API.
+    """
     try:
         uid = console_output_loader.text_buffer_uid
     except Exception:
         _process_exception()
     return {"success": True, "msg": "", "console_output_uid": uid}
+
+
+@app.get("/console_output_update")
+def console_output_update(payload: dict):
+    """
+    Download the list of new messages that were accumulated at the server. The API
+    accepts a require parameter ``last_msg_uid`` with UID of the last downloaded message.
+    If the UID is not found in the buffer, an empty message list and valid UID is
+    returned. If UID is ``"ALL"``, then all accumulated messages in the buffer is
+    returned. If UID is found in the buffer, then the list of new messages is returned.
+
+    At the client: initialize the system by sending request with ``last_msg_uid`` set
+    to random string or ``"ALL"``. In each request use ``last_msg_uid`` returned by the previous
+    request to download new messages.
+    """
+    try:
+        validate_payload_keys(payload, required_keys=["last_msg_uid"])
+
+        response = console_output_loader.get_new_msgs(last_msg_uid=payload["last_msg_uid"])
+        # Add 'success' and 'msg' so that the API is compatible with other QServer API.
+        response.update({"success": True, "msg": ""})
+    except Exception:
+        _process_exception()
+
+    return response


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of `console_output_update` API for monitoring of console output in polling mode.

## Description
<!--- Describe your changes in detail -->

The new `console_output_update` endpoint accepts required `last_msg_uid` parameter and returns a list of messages and UID of the last message in the buffer. If the internal buffer contains a message with this UID, then the API returns a list of all the following messages. If the UID is not found, then the empty list is returned. If UID is the string `"ALL"`, then the list of all messages contained in the buffer are returned.

In normal operation: first call the `console_output_update` endpoint with random UID or `"ALL"`, for the next calls use `last_msg_uid` returned by the previous calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The API is necessary to implement remote monitoring of console output in polling mode.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- `console_output_update` endpoint for monitoring of console output in polling mode. 

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented.
