### PR TITLE
Change requirements: 'requests' is now in 'requirements-dev.txt'

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ sphinx
 sphinx_rtd_theme
 # Extra dependencies for development
 fastapi[all]
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ bluesky-queueserver
 bluesky-queueserver-api
 fastapi
 pyzmq
-requests
 typing-extensions;python_version<'3.8'
 uvicorn
 starlette


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The `requests` package is now only development dependency, so it is moved to `requirements-dev.txt`. The package also needs  to be removed from the feedstock during the next release.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `requests` package is used only for unit tests.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- NOTE: remove `requests` package from requirements in `bluesky-httpserver-feedstock` before the next release.

### Removed
