### PR TITLE
Use standard environment variable names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,11 +93,13 @@ environment variable before starting the server::
 
 The Web Server supports using external modules for processing some requests. Those modules
 are optional and may contain custom instrument-specific processing code. The name of the external
-module may be passed to HTTP server by setting **QSERVER_CUSTOM_MODULE** environment
+modules may be passed to HTTP server by setting **QSERVER_CUSTOM_MODULES** environment
 variable::
 
-  QSERVER_CUSTOM_MODULE=<name-of-external-module> uvicorn bluesky_queueserver.server.server:app --host localhost --port 60610
+  QSERVER_CUSTOM_MODULES=<name-of-external-module> uvicorn bluesky_queueserver.server.server:app --host localhost --port 60610
 
+The value of the environment variable is a string containing a list of comma-separated module names.
+The first module that contains the required functions is selected and used by the server.
 If the module name contains '-' (dash) characters, they will be automatically converted to '_'
 (underscore) characters. If the server fails to load custom external module, the server
 will support only default functionality and may reject the requests that require custom processing.

--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,8 @@ variable::
 
   QSERVER_CUSTOM_MODULES=<name-of-external-module> uvicorn bluesky_queueserver.server.server:app --host localhost --port 60610
 
-The value of the environment variable is a string containing a list of comma-separated module names.
-The first module that contains the required functions is selected and used by the server.
+The value of the environment variable is a string containing a comma or column-separated list of
+module names. The first module that contains the required functions is selected and used by the server.
 If the module name contains '-' (dash) characters, they will be automatically converted to '_'
 (underscore) characters. If the server fails to load custom external module, the server
 will support only default functionality and may reject the requests that require custom processing.

--- a/README.rst
+++ b/README.rst
@@ -524,9 +524,9 @@ received after the web client connects to the server.
 
 If RE Manager is configured to publish console address to 0MQ socket with port number different from
 default or HTTP server is running on a separate workstation/server, the address of 0MQ socket
-can be specified by setting the environment variable ``QSERVER_ZMQ_ADDRESS_CONSOLE``, e.g. ::
+can be specified by setting the environment variable ``QSERVER_ZMQ_INFO_ADDRESS``, e.g. ::
 
-  export QSERVER_ZMQ_ADDRESS_CONSOLE='tcp://localhost:60625'
+  export QSERVER_ZMQ_INFO_ADDRESS='tcp://localhost:60625'
 
 
 Console Output of RE Manager

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -90,6 +90,11 @@ async def startup_event():
                 "QSERVER_ZMQ_INFO_ADDRESS to pass address of 0MQ information socket to HTTP Server."
             )
 
+    logger.info(
+        f"Connecting to RE Manager: \nControl 0MQ socket address: {zmq_control_addr}\n"
+        f"Information 0MQ socket address: {zmq_info_addr}"
+    )
+
     RM = REManagerAPI(
         zmq_control_addr=zmq_control_addr,
         zmq_info_addr=zmq_info_addr,

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -28,7 +28,7 @@ logging.getLogger("bluesky_queueserver").setLevel("DEBUG")
 # Use FastAPI
 app = FastAPI()
 
-custom_code_modules = None
+custom_code_modules = []
 console_output_loader = None
 
 RM = None
@@ -122,6 +122,7 @@ async def startup_event():
     logger.info(f"The following custom modules will be imported: {module_names}")
 
     # Import all listed custom modules
+    custom_code_modules.clear()
     for name in module_names:
         try:
             logger.info("Importing custom module '%s' ...", name)

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -60,23 +60,39 @@ async def startup_event():
             raise ValueError("ZMQ public key is improperly formatted: %s", str(ex))
 
     # TODO: implement nicer exit with error reporting in case of failure
-    zmq_server_address_control = os.getenv("QSERVER_ZMQ_ADDRESS_CONTROL", None)
-    if zmq_server_address_control is None:
+    zmq_control_addr = os.getenv("QSERVER_ZMQ_CONTROL_ADDRESS", None)
+    if zmq_control_addr is None:
+        zmq_control_addr = os.getenv("QSERVER_ZMQ_ADDRESS_CONTROL", None)
+        if zmq_control_addr is not None:
+            logger.warning(
+                "Environment variable QSERVER_ZMQ_ADDRESS_CONTROL is deprecated: use environment variable "
+                "QSERVER_ZMQ_CONTROL_ADDRESS to pass address of 0MQ control socket to HTTP Server."
+            )
+    if zmq_control_addr is None:
         # Support for deprecated environment variable QSERVER_ZMQ_ADDRESS.
         # TODO: remove in one of the future versions
-        zmq_server_address_control = os.getenv("QSERVER_ZMQ_ADDRESS", None)
-        if zmq_server_address_control is not None:
+        zmq_control_addr = os.getenv("QSERVER_ZMQ_ADDRESS", None)
+        if zmq_control_addr is not None:
             logger.warning(
                 "Environment variable QSERVER_ZMQ_ADDRESS is deprecated: use environment variable "
-                "QSERVER_ZMQ_ADDRESS_CONTROL to pass address of 0MQ control socket to HTTP Server."
+                "QSERVER_ZMQ_CONTROL_ADDRESS to pass address of 0MQ control socket to HTTP Server."
             )
 
-    zmq_server_address_console = os.getenv("QSERVER_ZMQ_ADDRESS_CONSOLE", None)
+    zmq_info_addr = os.getenv("QSERVER_ZMQ_INFO_ADDRESS", None)
+    if zmq_info_addr is None:
+        # Support for deprecated environment variable QSERVER_ZMQ_ADDRESS.
+        # TODO: remove in one of the future versions
+        zmq_info_addr = os.getenv("QSERVER_ZMQ_ADDRESS_CONSOLE", None)
+        if zmq_info_addr is not None:
+            logger.warning(
+                "Environment variable QSERVER_ZMQ_ADDRESS_CONSOLE is deprecated: use environment variable "
+                "QSERVER_ZMQ_INFO_ADDRESS to pass address of 0MQ information socket to HTTP Server."
+            )
 
     RM = REManagerAPI(
-        zmq_server_address=zmq_server_address_control,
-        zmq_subscribe_addr=zmq_server_address_console,
-        server_public_key=zmq_public_key,
+        zmq_control_addr=zmq_control_addr,
+        zmq_info_addr=zmq_info_addr,
+        zmq_public_key=zmq_public_key,
         request_fail_exceptions=False,
         status_expiration_period=0.4,  # Make it smaller than default
         console_monitor_max_lines=2000,

--- a/bluesky_httpserver/server/server.py
+++ b/bluesky_httpserver/server/server.py
@@ -1,6 +1,7 @@
 import logging
 import io
 import pprint
+import re
 import os
 import importlib
 
@@ -110,11 +111,11 @@ async def startup_event():
         logger.warning(
             "Environment variable QSERVER_CUSTOM_MODULE is deprecated and will be removed. "
             "Use the environment variable QSERVER_CUSTOM_MODULES, which accepts a string with "
-            "comma-separated modules."
+            "comma or colon-separated module names."
         )
     module_names = module_names or os.getenv("QSERVER_CUSTOM_MODULE", None)
     if isinstance(module_names, str):
-        module_names = module_names.split(",")
+        module_names = re.split(":|,", module_names)
     else:
         logger.info("The value of environment variable QSERVER_CUSTOM_MODULES is not a string")
         module_names = []

--- a/bluesky_httpserver/server/tests/conftest.py
+++ b/bluesky_httpserver/server/tests/conftest.py
@@ -31,10 +31,10 @@ def fastapi_server_fs(xprocess):
     to perform additional steps (such as setting environmental variables) before the server is started.
     """
 
-    def start():
+    def start(http_server_host=SERVER_ADDRESS, http_server_port=SERVER_PORT):
         class Starter(ProcessStarter):
             pattern = "Bluesky HTTP Server started successfully"
-            args = f"uvicorn --host={SERVER_ADDRESS} --port {SERVER_PORT} {bqss.__name__}:app".split()
+            args = f"uvicorn --host={http_server_host} --port {http_server_port} {bqss.__name__}:app".split()
 
         xprocess.ensure("fastapi_server", Starter)
 

--- a/bluesky_httpserver/server/tests/test_console_output.py
+++ b/bluesky_httpserver/server/tests/test_console_output.py
@@ -77,13 +77,13 @@ def test_http_server_stream_console_output_1(
     """
     # Start HTTP Server
     if zmq_port is not None:
-        monkeypatch.setenv("QSERVER_ZMQ_ADDRESS_CONSOLE", f"tcp://localhost:{zmq_port}")
+        monkeypatch.setenv("QSERVER_ZMQ_INFO_ADDRESS", f"tcp://localhost:{zmq_port}")
     fastapi_server_fs()
 
     # Start RE Manager
     params = ["--zmq-publish-console", "ON"]
     if zmq_port is not None:
-        params.extend(["--zmq-publish-console-addr", f"tcp://*:{zmq_port}"])
+        params.extend(["--zmq-info-addr", f"tcp://*:{zmq_port}"])
     re_manager_cmd(params)
 
     rsc = _ReceiveStreamedConsoleOutput()
@@ -153,13 +153,13 @@ def test_http_server_console_output_1(monkeypatch, re_manager_cmd, fastapi_serve
     """
     # Start HTTP Server
     if zmq_port is not None:
-        monkeypatch.setenv("QSERVER_ZMQ_ADDRESS_CONSOLE", f"tcp://localhost:{zmq_port}")
+        monkeypatch.setenv("QSERVER_ZMQ_INFO_ADDRESS", f"tcp://localhost:{zmq_port}")
     fastapi_server_fs()
 
     # Start RE Manager
     params = ["--zmq-publish-console", "ON"]
     if zmq_port is not None:
-        params.extend(["--zmq-publish-console-addr", f"tcp://*:{zmq_port}"])
+        params.extend(["--zmq-info-addr", f"tcp://*:{zmq_port}"])
     re_manager_cmd(params)
 
     script = _script1
@@ -214,6 +214,7 @@ def test_http_server_console_output_1(monkeypatch, re_manager_cmd, fastapi_serve
     resp3c = request_to_json("get", "/console_output", json={"nlines": 300})
     assert resp3c["success"] is True
     console_output = resp3c["text"]
+    assert re.search(expected_output, console_output)
 
 
 @pytest.mark.parametrize("zmq_port", (None, 60619))
@@ -225,13 +226,13 @@ def test_http_server_console_output_update_1(
     """
     # Start HTTP Server
     if zmq_port is not None:
-        monkeypatch.setenv("QSERVER_ZMQ_ADDRESS_CONSOLE", f"tcp://localhost:{zmq_port}")
+        monkeypatch.setenv("QSERVER_ZMQ_INFO_ADDRESS", f"tcp://localhost:{zmq_port}")
     fastapi_server_fs()
 
     # Start RE Manager
     params = ["--zmq-publish-console", "ON"]
     if zmq_port is not None:
-        params.extend(["--zmq-publish-console-addr", f"tcp://*:{zmq_port}"])
+        params.extend(["--zmq-info-addr", f"tcp://*:{zmq_port}"])
     re_manager_cmd(params)
 
     script = _script1

--- a/bluesky_httpserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_httpserver/server/tests/test_http_server_func_scope.py
@@ -71,17 +71,27 @@ def _create_test_excel_file1(tmp_path, *, plan_params, col_names):
     return ss_path, plans_expected
 
 
-def test_http_server_queue_upload_spreasheet_1(re_manager, fastapi_server_fs, tmp_path, monkeypatch):  # noqa F811
+# fmt: off
+@pytest.mark.parametrize("custom_module_list", [
+    # Colon-separated string
+    "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
+    "bluesky_queueserver.manager.tests.spreadsheet_custom_functions:bluesky_queueserver_api",
+    "bluesky_queueserver_api:bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
+    "bluesky_queueserver.manager.tests.spreadsheet_custom_functions:non.existing.package",
+    "non.existing.package:bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
+    # Comma-separated string
+    "bluesky_queueserver_api:bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
+])
+# fmt: on
+def test_http_server_queue_upload_spreasheet_1(
+    re_manager, fastapi_server_fs, tmp_path, monkeypatch, custom_module_list  # noqa F811
+):
     """
     Test for ``/queue/upload/spreadsheet`` API: generate .xlsx file, upload it to the server, verify
     the contents of the queue, run the queue and verify that the required number of plans were successfully
     completed.
     """
-    monkeypatch.setenv(
-        "QSERVER_CUSTOM_MODULES",
-        "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
-        prepend=False,
-    )
+    monkeypatch.setenv("QSERVER_CUSTOM_MODULES", custom_module_list, prepend=False)
     fastapi_server_fs()
 
     plan_params = [["count", 5, 1], ["count", 6, 0.5]]

--- a/bluesky_httpserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_httpserver/server/tests/test_http_server_func_scope.py
@@ -25,7 +25,7 @@ from bluesky_httpserver.server.tests.conftest import (  # noqa F401
     wait_for_manager_state_idle,
 )
 
-from bluesky_queueserver.manager.comms import generate_new_zmq_key_pair
+from bluesky_queueserver import generate_zmq_keys
 
 
 # Plans used in most of the tests: '_plan1' and '_plan2' are quickly executed '_plan3' runs for 5 seconds.
@@ -301,14 +301,14 @@ def test_http_server_secure_1(monkeypatch, re_manager_cmd, fastapi_server_fs, te
     Test operation of HTTP server with enabled encryption. Security of HTTP server can be enabled
     only by setting the environment variable to the value of the public key.
     """
-    public_key, private_key = generate_new_zmq_key_pair()
+    public_key, private_key = generate_zmq_keys()
 
     if test_mode == "none":
         # No encryption
         pass
     elif test_mode == "ev":
         # Set server private key using environment variable
-        monkeypatch.setenv("QSERVER_ZMQ_PRIVATE_KEY", private_key)  # RE Manager
+        monkeypatch.setenv("QSERVER_ZMQ_PRIVATE_KEY_FOR_SERVER", private_key)  # RE Manager
         monkeypatch.setenv("QSERVER_ZMQ_PUBLIC_KEY", public_key)  # HTTP server
         set_qserver_zmq_public_key(monkeypatch, server_public_key=public_key)  # For test functions
     else:

--- a/bluesky_httpserver/server/tests/test_http_server_func_scope.py
+++ b/bluesky_httpserver/server/tests/test_http_server_func_scope.py
@@ -78,7 +78,7 @@ def test_http_server_queue_upload_spreasheet_1(re_manager, fastapi_server_fs, tm
     completed.
     """
     monkeypatch.setenv(
-        "QSERVER_CUSTOM_MODULE",
+        "QSERVER_CUSTOM_MODULES",
         "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
         prepend=False,
     )
@@ -139,7 +139,7 @@ def test_http_server_queue_upload_spreasheet_2(re_manager, fastapi_server_fs, tm
     return error message. Verify that correct error message is returned.
     """
     monkeypatch.setenv(
-        "QSERVER_CUSTOM_MODULE",
+        "QSERVER_CUSTOM_MODULES",
         "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
         prepend=False,
     )
@@ -165,7 +165,7 @@ def test_http_server_queue_upload_spreasheet_3(re_manager, fastapi_server_fs, tm
     on file extension) and check the returned error message.
     """
     monkeypatch.setenv(
-        "QSERVER_CUSTOM_MODULE",
+        "QSERVER_CUSTOM_MODULES",
         "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
         prepend=False,
     )
@@ -202,7 +202,7 @@ def test_http_server_queue_upload_spreasheet_4(
     """
     if use_custom:
         monkeypatch.setenv(
-            "QSERVER_CUSTOM_MODULE",
+            "QSERVER_CUSTOM_MODULES",
             "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
             prepend=False,
         )
@@ -256,7 +256,7 @@ def test_http_server_queue_upload_spreasheet_5(re_manager, fastapi_server_fs, tm
     will contain ``success`` status and error message for each plan.
     """
     monkeypatch.setenv(
-        "QSERVER_CUSTOM_MODULE",
+        "QSERVER_CUSTOM_MODULES",
         "bluesky_queueserver.manager.tests.spreadsheet_custom_functions",
         prepend=False,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Use standard names for environment variables that specify addresses and public key for RE Manager. The following environment variables are supported:

- `QSERVER_ZMQ_CONTROL_ADDRESS` - address of the control socket of RE Manager;
- `QSERVER_ZMQ_INFO_ADDRESS` - address of the socket used for publishing console output;
- `QSERVER_ZMQ_PUBLIC_KEY` - public key for encrypted communication with RE Manager.

The existing keys are deprecated and will be removed in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The environment variable names are consistent with conventions established in PR https://github.com/bluesky/bluesky-queueserver/pull/234

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed

- Implemented support for standard environment variable names. Old names are deprecated and will be removed in the future. The  following environment variables are supported:
  
  - `QSERVER_ZMQ_CONTROL_ADDRESS` - address of the control socket of RE Manager;
  - `QSERVER_ZMQ_INFO_ADDRESS` - address of the socket used for publishing console output;
  - `QSERVER_ZMQ_PUBLIC_KEY` - public key for encrypted communication with RE Manager.


### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
