### PR TITLE
Convert 'max_age' parameters from 'int' to 'datetime.timedelta'

### DIFF
--- a/bluesky_httpserver/config.py
+++ b/bluesky_httpserver/config.py
@@ -4,6 +4,7 @@ This module handles server configuration.
 See profiles.py for client configuration.
 """
 import copy
+from datetime import timedelta
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -53,6 +54,10 @@ def construct_build_app_kwargs(
             authenticator = authenticator_class(**authenticator.get("args", {}))
             # Replace "package.module:Object" with live instance.
             auth_spec["providers"][i]["authenticator"] = authenticator
+        # The following parameters are integers, which should be changed to 'timedelta'
+        for k in ("access_token_max_age", "refresh_token_max_age", "session_max_age"):
+            if k in auth_spec:
+                auth_spec[k] = timedelta(seconds=auth_spec[k])
 
         server_settings = {}
         server_settings["allow_origins"] = config.get("allow_origins")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Minor fix: the parameters `access_token_max_age`, `refresh_token_max_age` and `session_max_age` loaded from `.yml` config file are represented as integers (seconds), while the server code requires that they are represented as `datetime.timedelta` (this is how the default parameters and parameters passed as EVs are represented). Incorrect type results in exception being raised during processing of login requests, which require generating a token. The PR adds the code that converts the parameters to `datetime.timedelta` type before they are passed to the server.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- Proper handling of parameters `access_token_max_age`, `refresh_token_max_age` and `session_max_age` loaded from config YML file.

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
