### PR TITLE
Non-blocking LDAP authenticator

### DIFF
--- a/bluesky_httpserver/authenticators.py
+++ b/bluesky_httpserver/authenticators.py
@@ -330,8 +330,11 @@ class LDAPAuthenticator:
 
     Parameters
     ----------
-    server_address: str
-        Address of the LDAP server to contact.
+    server_address: str or list(str)
+        Address(es) of the LDAP server(s) to contact. A string value may represent a single 
+        server, a list of strings may represent one or more servers. If a server address
+        includes port, then the value of ``server_port`` is ignored, otherwise ``server_port``
+        or the default port is used to access the server.
 
         Could be an IP address or hostname.
     server_port: int or None

--- a/bluesky_httpserver/authenticators.py
+++ b/bluesky_httpserver/authenticators.py
@@ -331,7 +331,7 @@ class LDAPAuthenticator:
     Parameters
     ----------
     server_address: str or list(str)
-        Address(es) of the LDAP server(s) to contact. A string value may represent a single 
+        Address(es) of the LDAP server(s) to contact. A string value may represent a single
         server, a list of strings may represent one or more servers. If a server address
         includes port, then the value of ``server_port`` is ignored, otherwise ``server_port``
         or the default port is used to access the server.

--- a/bluesky_httpserver/authenticators.py
+++ b/bluesky_httpserver/authenticators.py
@@ -552,9 +552,9 @@ class LDAPAuthenticator:
         if self.escape_userdn:
             search_dn = ldap3.utils.conv.escape_filter_chars(search_dn)
         conn = await asyncio.get_running_loop().run_in_executor(
-            self.get_connection, userdn=search_dn, password=self.lookup_dn_search_password
+            None, self.get_connection, search_dn, self.lookup_dn_search_password
         )
-        is_bound = await asyncio.get_running_loop().run_in_executor(conn.bind)
+        is_bound = await asyncio.get_running_loop().run_in_executor(None, conn.bind)
         if not is_bound:
             msg = "Failed to connect to LDAP server with search user '{search_dn}'"
             self.log.warning(msg.format(search_dn=search_dn))
@@ -685,7 +685,9 @@ class LDAPAuthenticator:
             logger.debug(msg.format(username=username, userdn=userdn))
             msg = "Status of user bind {username} with {userdn} : {is_bound}"
             try:
-                conn = await asyncio.get_running_loop().run_in_executor(self.get_connection, userdn, password)
+                conn = await asyncio.get_running_loop().run_in_executor(
+                    None, self.get_connection, userdn, password
+                )
             except ldap3.core.exceptions.LDAPBindError as exc:
                 is_bound = False
                 msg += "\n{exc_type}: {exc_msg}".format(
@@ -693,7 +695,9 @@ class LDAPAuthenticator:
                     exc_msg=exc.args[0] if exc.args else "",
                 )
             else:
-                is_bound = True if conn.bound else await asyncio.get_running_loop().run_in_executor(conn.bind)
+                is_bound = (
+                    True if conn.bound else await asyncio.get_running_loop().run_in_executor(None, conn.bind)
+                )
             msg = msg.format(username=username, userdn=userdn, is_bound=is_bound)
             logger.debug(msg)
             if is_bound:

--- a/bluesky_httpserver/authenticators.py
+++ b/bluesky_httpserver/authenticators.py
@@ -695,9 +695,11 @@ class LDAPAuthenticator:
                     exc_msg=exc.args[0] if exc.args else "",
                 )
             else:
-                is_bound = (
-                    True if conn.bound else await asyncio.get_running_loop().run_in_executor(None, conn.bind)
-                )
+                if conn.bound:
+                    is_bound = True
+                else:
+                    is_bound = await asyncio.get_running_loop().run_in_executor(None, conn.bind)
+                    
             msg = msg.format(username=username, userdn=userdn, is_bound=is_bound)
             logger.debug(msg)
             if is_bound:

--- a/bluesky_httpserver/tests/test_authenticators.py
+++ b/bluesky_httpserver/tests/test_authenticators.py
@@ -4,8 +4,21 @@ import pytest
 from ..authenticators import LDAPAuthenticator
 
 
+# fmt: off
+@pytest.mark.parametrize("ldap_server_address, ldap_server_port", [
+    ("localhost", 1389),
+    ("localhost:1389", 904),  # Random port, ignored
+    ("localhost:1389", None),
+    ("127.0.0.1", 1389),
+    ("127.0.0.1:1389", 904),
+    (["localhost"], 1389),
+    (["localhost", "127.0.0.1"], 1389),
+    (["localhost", "127.0.0.1:1389"], 1389),
+    (["localhost:1389", "127.0.0.1:1389"], None),
+])
+# fmt: on
 @pytest.mark.parametrize("use_tls,use_ssl", [(False, False)])
-def test_LDAPAuthenticator_01(use_tls, use_ssl):
+def test_LDAPAuthenticator_01(use_tls, use_ssl, ldap_server_address, ldap_server_port):
     """
     Basic test for ``LDAPAuthenticator``.
 
@@ -13,8 +26,8 @@ def test_LDAPAuthenticator_01(use_tls, use_ssl):
     of the LDAP server.
     """
     authenticator = LDAPAuthenticator(
-        "localhost",
-        1389,
+        ldap_server_address,
+        ldap_server_port,
         bind_dn_template="cn={username},ou=users,dc=example,dc=org",
         use_tls=use_tls,
         use_ssl=use_ssl,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,15 +3,13 @@
 black
 codecov
 coverage
+fastapi[all]
 flake8
 pytest
 pytest-xprocess
 sphinx
-# These are dependencies of various sphinx extensions for documentation.
 ipython
 numpydoc
 sphinx
 sphinx_rtd_theme
-# Extra dependencies for development
-fastapi[all]
 requests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of non-blocking LDAP authenticator.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New parameters of `LDAPAuthenticator`: `connect_timeout`, `receive_timeout`.

### Changed

- `LDAPAuthenticator` is now not blocking the server event loop while waiting for the response from the server.
- `LDAPAuthenticator` now works with the pool of LDAP servers. The parameter `server_address` accepts a string representing a single server or a list of strings representing multiple servers.

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

