### PR TITLE
Support for 0MQ and server configuration parameters in the config YML file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Bluesky HTTP Server implements REST API for controlling experiments using Queue 
 
 * Free software: 3-clause BSD license
 * `Installation instructions <https://bluesky.github.io/bluesky-httpserver/installation.html>`_.
-* `Brief description of the project <https://bluesky.github.io/bluesky-httpserver/introduction.html>`_.
+* `Overview of the project <https://bluesky.github.io/bluesky-httpserver/introduction.html>`_.
 * `Guide to API for experiment control <https://bluesky.github.io/bluesky-httpserver/control_re_manager.html>`_.
 * `Full documentation <https://bluesky.github.io/bluesky-httpserver>`_.
 * `'bluesky-queueserver': Queue Server (Run Engine Manager) <https://bluesky.github.io/bluesky-queueserver>`_.

--- a/bluesky_httpserver/app.py
+++ b/bluesky_httpserver/app.py
@@ -367,8 +367,8 @@ def build_app(authentication=None, api_access=None, resource_access=None, server
         module_names_str = module_names_str or os.getenv("QSERVER_CUSTOM_MODULE", None)
 
         module_names = []
-        if "custom_routers" in server_settings["server_configuration"]:
-            module_names = server_settings["server_configuration"]["custom_routers"]
+        if "custom_modules" in server_settings["server_configuration"]:
+            module_names = server_settings["server_configuration"]["custom_modules"]
             logger.info("Custom modules from config file: %s", pprint.pformat(module_names))
         elif module_names_str:
             module_names = re.split(":|,", module_names_str)

--- a/bluesky_httpserver/config.py
+++ b/bluesky_httpserver/config.py
@@ -84,6 +84,8 @@ def construct_build_app_kwargs(
                     f"({prometheus_multiproc_dir}) is not writable"
                 )
         server_settings["metrics"] = metrics
+        server_settings["qserver_zmq_settings"] = config.get("qserver_zmq_settings", {})
+        server_settings["server_configuration"] = config.get("server_configuration", {})
     return {
         "authentication": auth_spec,
         "api_access": api_access_spec,

--- a/bluesky_httpserver/config.py
+++ b/bluesky_httpserver/config.py
@@ -102,8 +102,8 @@ def merge(configs):
 
     # These variables are used to produce error messages that point
     # to the relevant config file(s).
-    qserver_zmq_configuration_config_source = None
-    server_configuration_config_source = None
+    qserver_zmq_config_source = None
+    server_config_source = None
     authentication_config_source = None
     uvicorn_config_source = None
     metrics_config_source = None
@@ -117,20 +117,20 @@ def merge(configs):
         if "qserver_zmq_configuration" in config:
             if "qserver_zmq_configuration" in merged:
                 raise ConfigError(
-                    "qserver zmq settings can only be specified in one file. "
-                    f"It was found in both {qserver_zmq_configuration_config_source} and "
+                    "'qserver_zmq_configuration' can only be specified in one file. "
+                    f"It was found in both {qserver_zmq_config_source} and "
                     f"{filepath}"
                 )
-            qserver_zmq_configuration_config_source = filepath
+            qserver_zmq_config_source = filepath
             merged["qserver_zmq_configuration"] = config["qserver_zmq_configuration"]
         if "server_configuration" in config:
             if "server_configuration" in merged:
                 raise ConfigError(
-                    "server configuration can only be specified in one file. "
-                    f"It was found in both {server_configuration_config_source} and "
+                    "'server_configuration' can only be specified in one file. "
+                    f"It was found in both {server_config_source} and "
                     f"{filepath}"
                 )
-            server_configuration_config_source = filepath
+            server_config_source = filepath
             merged["server_configuration"] = config["server_configuration"]
         if "authentication" in config:
             if "authentication" in merged:

--- a/bluesky_httpserver/config.py
+++ b/bluesky_httpserver/config.py
@@ -87,7 +87,7 @@ def construct_build_app_kwargs(
                     f"({prometheus_multiproc_dir}) is not writable"
                 )
         server_settings["metrics"] = metrics
-        server_settings["qserver_zmq_settings"] = config.get("qserver_zmq_settings", {})
+        server_settings["qserver_zmq_configuration"] = config.get("qserver_zmq_configuration", {})
         server_settings["server_configuration"] = config.get("server_configuration", {})
     return {
         "authentication": auth_spec,
@@ -102,7 +102,7 @@ def merge(configs):
 
     # These variables are used to produce error messages that point
     # to the relevant config file(s).
-    qserver_zmq_settings_config_source = None
+    qserver_zmq_configuration_config_source = None
     server_configuration_config_source = None
     authentication_config_source = None
     uvicorn_config_source = None
@@ -114,15 +114,15 @@ def merge(configs):
 
     for filepath, config in configs.items():
         allow_origins.extend(config.get("allow_origins", []))
-        if "qserver_zmq_settings" in config:
-            if "qserver_zmq_settings" in merged:
+        if "qserver_zmq_configuration" in config:
+            if "qserver_zmq_configuration" in merged:
                 raise ConfigError(
                     "qserver zmq settings can only be specified in one file. "
-                    f"It was found in both {qserver_zmq_settings_config_source} and "
+                    f"It was found in both {qserver_zmq_configuration_config_source} and "
                     f"{filepath}"
                 )
-            qserver_zmq_settings_config_source = filepath
-            merged["qserver_zmq_settings"] = config["qserver_zmq_settings"]
+            qserver_zmq_configuration_config_source = filepath
+            merged["qserver_zmq_configuration"] = config["qserver_zmq_configuration"]
         if "server_configuration" in config:
             if "server_configuration" in merged:
                 raise ConfigError(

--- a/bluesky_httpserver/config_schemas/service_configuration.yml
+++ b/bluesky_httpserver/config_schemas/service_configuration.yml
@@ -14,7 +14,7 @@ $schema": http://json-schema.org/draft-07/schema#
 type: object
 additionalProperties: false
 properties:
-  qserver_zmq_settings:
+  qserver_zmq_configuration:
     type: [object]
     additionalProperties: false
     properties:

--- a/bluesky_httpserver/config_schemas/service_configuration.yml
+++ b/bluesky_httpserver/config_schemas/service_configuration.yml
@@ -14,6 +14,47 @@ $schema": http://json-schema.org/draft-07/schema#
 type: object
 additionalProperties: false
 properties:
+  qserver_zmq_settings:
+    type: [object]
+    additionalProperties: false
+    properties:
+      control_address:
+        type: string
+        description: |
+          The address of 0MQ control (REQ-REP) socket of RE Manager, e.g. tcp://localhost:60615.
+          Overrides the address set using QSERVER_ZMQ_CONTROL_ADDRESS environment variable.
+      info_address:
+        type: string
+        description: |
+          The address of 0MQ info (PUB-SUB) socket of RE Manager, used to publish console output
+          e.g. tcp://localhost:60625. Overrides the address set using QSERVER_ZMQ_INFO_ADDRESS
+          environment variable
+      public_key:
+        type: string
+        description: |
+          Public key used to encode control messages sent to RE Manager. Typically the public
+          key is passed using the environment variable QSERVER_ZMQ_PUBLIC_KEY (recommended),
+          but it could be specified in the config file, e.g. as a name of a different environment
+          variable (such as ${PUBLIC_KEY}) if needed. Overrides the public key set using
+          QSERVER_ZMQ_PUBLIC_KEY environment variable.
+  server_configuration:
+    type: [object]
+    additionalProperties: false
+    properties:
+      custom_routers:
+        type: array
+        item:
+          type: string
+        description: |
+          The list of Python modules with custom routers. Overrides the list of modules set using
+          QSERVER_HTTP_CUSTOM_ROUTERS environment variable.
+      custom_modules:
+        type: array
+        item:
+          type: string
+        description: |
+          THE FUNCTIONALITY WILL BE DEPRECATED IN FAVOR OF CUSTOM ROUTERS. Overrides the list of modules
+          set using QSERVER_CUSTOM_MODULES environment variable.
   authentication:
     type: [object, "null"]
     additionalProperties: false

--- a/bluesky_httpserver/tests/conftest.py
+++ b/bluesky_httpserver/tests/conftest.py
@@ -62,6 +62,7 @@ def setup_server_with_config_file(*, config_file_str, tmpdir, monkeypatch):
     Creates config file for the server in ``tmpdir/config/`` directory and
     sets up the respective environment variable. Sets ``tmpdir`` as a current directory.
     """
+    print(f"SERVER CONFIGURATION:\n{'-'*50}\n{config_file_str}\n{'-'*50}")
     config_fln = "config_httpserver.yml"
     config_dir = os.path.join(tmpdir, "config")
     config_path = os.path.join(config_dir, config_fln)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -82,9 +82,8 @@ run 'out of the box' if all system components are running on the same machine, w
 is the case in testing and simple demos. In practical deployments the settings need to be
 customized.
 
-Currently, the configuration for 0MQ communication with RE Manager can be customized Only
-using environment variables. Support for the respective configuration options will be 
-added to the server config files in the future.
+The configuration for 0MQ communication with RE Manager can be customized using environment 
+variables or configuration files. 
 
 The following environment variables are used to configure 0MQ communication settings:
 
@@ -100,6 +99,36 @@ The following environment variables are used to configure 0MQ communication sett
   `'qserver-zmq-keys' CLI tool <https://blueskyproject.io/bluesky-queueserver/cli_tools.html#qserver-zmq-keys>`_, 
   pass the private key to RE Manager. Pass the public key to HTTP Server using 
   ``QSERVER_ZMQ_PUBLIC_KEY`` environment variable.
+
+The same parameters can be specified by including ``qserver_zmq_configuration`` into
+the config file::
+
+  qserver_zmq_configuration:
+    control_address: tcp://localhost:60615
+    info_address: tcp://localhost:60625
+    public_key: ${PUBLIC_KEY}
+
+All parameters in the config file are optional and override the values passed using 
+environment variables and the default values. The public key is typically passed using environment
+variable ``QSERVER_ZMQ_PUBLIC_KEY``, but different environment variable name could be specified
+in the config file as in the example above. Explicitly including public key in the config file
+is considered unsafe practice in production systems.
+
+Custom Routers
+**************
+
+The HTTP Server can be extended to support application-specific functionality by developing
+Python modules with custom routers. The module names are passed to the server as ``:``-separated 
+list using the environment variable ``QSERVER_HTTP_CUSTOM_ROUTERS``::
+
+  export QSERVER_HTTP_CUSTOM_ROUTERS modu.le1:mod.ule2
+
+Alternatively, the list of modules can be specified in the configuration file::
+
+  server_configuration:
+    custom_routers:
+      - modu.le1
+      - mod.ule2
 
 Authentication
 **************


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added support for passing several parameters in the config YML file. Before the change, the parameters could be passed to the server only using the environment variables:

- `QSERVER_ZMQ_CONTROL_ADDRESS`
- `QSERVER_ZMQ_INFO_ADDRESS`
- `QSERVER_ZMQ_PUBLIC_KEY`
- `QSERVER_HTTP_CUSTOM_ROUTERS`

The respective sections of YML file would look the following:

```
qserver_zmq_configuration:
  control_address: tcp://localhost:60615
  info_address: tcp://localhost:60625
  public_key: ${PUBLIC_KEY}
server_configuration:
  custom_routers:
    - modu.le1
    - mod.ule2
```

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- The parameters passed using the environment variables `QSERVER_ZMQ_CONTROL_ADDRESS`, `QSERVER_ZMQ_INFO_ADDRESS`, `QSERVER_ZMQ_PUBLIC_KEY` and `QSERVER_HTTP_CUSTOM_ROUTERS` can now be passed in the configuration YML file.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing unit tests were modified to test whether each parameter can be passed using a config file and if settings in the config file override the respective environment variables.
