### PR TITLE
Comment 'scipy' and 'pandas' intersphinx mapping (documentation)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,7 +195,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    # 'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'matplotlib': ('https://matplotlib.org/stable', None),
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove `scipy` and `pandas` from intersphinx mapping, since it is not used in documentation and connection is unreliable and periodically causes build issues.
