### PR TITLE
Access control based on API Server

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,5 +7,6 @@ exclude =
     versioneer.py,
     bluesky_queueserver/_version.py,
     docs/source/conf.py
-ignore = E203, W503  # There are some errors produced by 'black', therefore unavoidable
+# There are some errors produced by 'black', therefore unavoidable
+ignore = E203, W503
 max-line-length = 115

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
 
     steps:

--- a/bluesky_httpserver/app.py
+++ b/bluesky_httpserver/app.py
@@ -38,7 +38,8 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 logging.basicConfig(level=logging.WARNING)
-logging.getLogger("bluesky_queueserver").setLevel("DEBUG")
+# logging.getLogger("bluesky_queueserver").setLevel("DEBUG")
+logging.getLogger(__name__).setLevel("DEBUG")
 
 SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
 SENSITIVE_COOKIES = {
@@ -227,6 +228,7 @@ def build_app(authentication=None, api_access=None, resource_access=None, server
         background_tasks = []
         for authenticator in authenticators:
             background_tasks.extend(getattr(authenticator, "background_tasks", []))
+        background_tasks.extend(getattr(api_access_manager, "background_tasks", []))
         for task in background_tasks or []:
             asyncio_task = asyncio.create_task(task())
             app.state.tasks.append(asyncio_task)

--- a/bluesky_httpserver/authorization/__init__.py
+++ b/bluesky_httpserver/authorization/__init__.py
@@ -1,3 +1,7 @@
-from .api_access import BasicAPIAccessControl, DictionaryAPIAccessControl  # noqa: F401
+from .api_access import (  # noqa: F401
+    BasicAPIAccessControl,
+    DictionaryAPIAccessControl,
+    ServerBasedAPIAccessControl,
+)
 from .resource_access import DefaultResourceAccessControl  # noqa: F401
 from ._defaults import _DEFAULT_USERNAME_SINGLE_USER, _DEFAULT_USERNAME_PUBLIC  # noqa: F401

--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -485,12 +485,13 @@ properties:
 
 class ServerBasedAPIAccessControl(BasicAPIAccessControl):
     """
-    API access policy, which is using access control information provided by dedicated
-    REST API server. The information is requested from the server by calling
-    ``/instruments/{instrument}/{endstation}/qserver/access`` API, where ``instrument``
-    and ``endstation`` are the strings passed with the respective class constructor parameters.
-    The API is expected to return a dictionary which maps roles ('admin', 'expert', 'advanced',
-    'user', 'observer') to dictionaries with user information, for example
+    Access policy based on external Access Control Server. The user access data is
+    periodically requested from the server using REST API. The access control server is
+    expected to expose ``/instruments/{instrument}/{endstation}/qserver/access`` API,
+    where ``instrument`` and ``endstation`` are the identifiers of the instrument and
+    endstation (optional) passed as class constructor parameters. The API is expected to
+    return a dictionary which maps roles ('admin', 'expert', 'advanced', 'user', 'observer')
+    to dictionaries with information on users that are assigned the role, for example
 
     .. code-block::
 
@@ -532,10 +533,10 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         The dictionary that defines new and/or modifies existing roles. The dictionary
         is passed to the ``BasicAPIAccessControl`` constructor. Default: ``None``.
     server: str, optional
-        Server address, such as ``'some.server.com'`` or ``'110.43.6.45'``. The default
-        address is ``localhost``.
+        Access Control server address, such as ``'accesscontrol.server.com'`` or
+        ``'110.43.6.45'``. The default address is ``localhost``.
     port: int, optional
-        Server port. The default port is `8000`.
+        Access Control server port. The default port is `8000`.
     update_period: int, optional
         Average period in seconds between consecutive requests for updated access data.
         The actual period is randomized (uniform distribution in the range +/-20% of

--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -459,7 +459,6 @@ class DictionaryAPIAccessControl(BasicAPIAccessControl):
         self._user_info.update(user_info)
 
 
-
 _schema_ServerBasedAPIAccessControl = """
 $schema": http://json-schema.org/draft-07/schema#
 type: object
@@ -504,7 +503,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         super().__init__(roles=roles)
 
         if instrument is None:
-          raise ConfigError("The required parameter 'instrument' is not specified")
+            raise ConfigError("The required parameter 'instrument' is not specified")
 
         try:
             config = {

--- a/bluesky_httpserver/tests/access_api_server/api_server.py
+++ b/bluesky_httpserver/tests/access_api_server/api_server.py
@@ -19,7 +19,7 @@ _access_info = {
     "observer": {},
 }
 
-_instrument = "TST"
+_instrument = "tst"
 _endstation = "default"
 
 _delay = 0

--- a/bluesky_httpserver/tests/access_api_server/api_server.py
+++ b/bluesky_httpserver/tests/access_api_server/api_server.py
@@ -1,0 +1,82 @@
+import asyncio
+import copy
+import fastapi
+import logging
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(level=logging.WARNING)
+logger.setLevel("INFO")
+
+router = fastapi.APIRouter()
+
+_access_info = {
+    "admin": {},
+    "expert": {},
+    "advanced": {},
+    "user": {},
+    "observer": {},
+}
+
+_instrument = "TST"
+_endstation = "default"
+
+_delay = 0
+
+app = fastapi.FastAPI()
+
+
+@app.on_event("startup")
+async def startup_event():
+    logger.info("Access API Server started successfully.")
+
+
+def _get_qserver_group_members(*, beamline, endstation):
+    return _access_info
+
+
+@router.get("/instruments/{instrument}/{endstation}/qserver/access")
+async def get_access_info(instrument: str, endstation: str):
+    # The delay is intended for testing timeouts.
+    await asyncio.sleep(_delay)
+    if instrument != _instrument:
+        raise HTTPException(status_code=406, detail=f"Unknown instrument: {instrument!r}")
+    if endstation != _endstation:
+        raise HTTPException(status_code=406, detail=f"Unknown endstation: {endstation!r}")
+    return _get_qserver_group_members(beamline=instrument, endstation=endstation)
+
+
+# ================================================================================
+#        The following API are intended exclusively for using in unit tests
+
+
+@router.post("/test/set_info")
+async def _set_info(access_info: dict):
+    global _access_info
+    _access_info = copy.deepcopy(access_info)
+
+
+@router.post("/test/set_instrument")
+async def _set_instrument(instrument: dict):
+    global _instrument
+    _instrument = copy.deepcopy(instrument)
+
+
+@router.post("/test/set_endstation")
+async def _set_endstation(endstation: dict):
+    global _endstation
+    _endstation = copy.deepcopy(endstation)
+
+
+@router.post("/test/set_delay")
+async def _set_delay(delay: dict):
+    global _delay
+    _delay = copy.deepcopy(delay)
+
+
+def configure_routing():
+    app.include_router(router)
+
+
+configure_routing()

--- a/bluesky_httpserver/tests/test_access_policies.py
+++ b/bluesky_httpserver/tests/test_access_policies.py
@@ -1,8 +1,16 @@
+import asyncio
+import copy
+import pprint
 import pytest
+import requests
+import time as ttime
+import threading
+from xprocess import ProcessStarter
 
 from bluesky_httpserver.authorization import (
     BasicAPIAccessControl,
     DictionaryAPIAccessControl,
+    ServerBasedAPIAccessControl,
     DefaultResourceAccessControl,
 )
 from bluesky_httpserver.config_schemas.loading import ConfigError
@@ -15,6 +23,7 @@ from bluesky_httpserver.authorization._defaults import (
     _DEFAULT_ROLE_PUBLIC,
     _DEFAULT_SCOPES_PUBLIC,
     _DEFAULT_RESOURCE_ACCESS_GROUP,
+    _DEFAULT_USER_INFO,
 )
 
 
@@ -202,6 +211,198 @@ def test_DictionaryAPIAccessControl_02(params, existing_scopes, missing_scopes):
     scopes = ac_manager.get_user_scopes(name)
     assert "read:status" in scopes
     assert "write:permissions" not in scopes
+
+
+@pytest.fixture
+def access_api_server(xprocess):
+    server_module = "bluesky_httpserver.tests.access_api_server.api_server"
+    server_address = "localhost"
+    server_port = 60001
+
+    class Starter(ProcessStarter):
+        pattern = "Access API Server started successfully"
+        args = f"uvicorn --host={server_address} --port {server_port} {server_module}:app".split()
+
+    xprocess.ensure("access_api_server", Starter)
+
+    yield
+
+    xprocess.getinfo("access_api_server").terminate()
+
+
+_user_access_info_1 = {
+    "bob": {
+        "roles": ["admin", "expert"],
+        "mail": "bob@mail.com",
+        "displayed_name": "Doe, Bob",
+    },
+    "alice": {"roles": ["advanced"], "mail": "alice@mail.com"},
+    "tom": {"roles": ["user"], "displayed_name": "Doe, Tom"},
+    "cara": {"roles": ["observer"]},
+}
+
+
+def user_access_info_to_groups(user_access_info):
+    groups = {}
+    for username, user_info in user_access_info.items():
+        for role in user_info["roles"]:
+            groups.setdefault(role, {})
+            groups[role].setdefault(username, {})
+            if "displayed_name" in user_info:
+                groups[role][username].update({"displayed_name": user_info["displayed_name"]})
+            if "mail" in user_info:
+                groups[role][username].update({"mail": user_info["mail"]})
+    return groups
+
+
+# fmt: off
+@pytest.mark.parametrize("n_requests", [1, 2, 3])
+# fmt: on
+def test_ServerBasedAPIAccessControl_01(access_api_server, n_requests):
+    """
+    ServerBasedAPIAccessControl: basic test
+    """
+    groups = user_access_info_to_groups(_user_access_info_1)
+    requests.post("http://localhost:60001/test/set_info", json=groups)
+
+    ac_manager = ServerBasedAPIAccessControl(
+        server="localhost", port=60001, update_period=2, http_timeout=1, instrument="TST", endstation="default"
+    )
+
+    # Read user info from the API server (once)
+    async def read_info():
+        for _ in range(n_requests):
+            await ac_manager.request_authentication_info()
+
+    asyncio.run(read_info())
+
+    # Verify loaded user info
+    expected_info = copy.deepcopy(_user_access_info_1)
+    expected_info.update(_DEFAULT_USER_INFO)
+    assert ac_manager._user_info == expected_info
+
+    # Recognizing users
+    assert ac_manager.is_user_known("bob")
+    assert not ac_manager.is_user_known("unknown_user")
+
+    # Checking roles
+    for username, user_info in _user_access_info_1.items():
+        assert ac_manager.get_user_roles(username) == set(user_info["roles"])
+
+    # Checking name formatting
+    assert ac_manager.get_displayed_user_name("bob") == 'bob "Doe, Bob <bob@mail.com>"'
+
+    # Brief check of scopes
+    assert "admin:apikeys" in ac_manager.get_user_scopes("bob")
+    assert "admin:apikeys" not in ac_manager.get_user_scopes("alice")
+
+
+def test_ServerBasedAPIAccessControl_02(access_api_server):
+    """
+    ServerBasedAPIAccessControl: periodic updates
+    """
+    groups = user_access_info_to_groups(_user_access_info_1)
+    requests.post("http://localhost:60001/test/set_info", json=groups)
+
+    ac_manager = ServerBasedAPIAccessControl(
+        server="localhost", port=60001, update_period=2, http_timeout=1, instrument="TST", endstation="default"
+    )
+
+    stop_loop = False
+
+    def func():
+        # Read user info from the API server (once)
+        async def read_info():
+            task = asyncio.create_task(ac_manager.background_update_authentication_info())
+            while True:
+                await asyncio.sleep(0.1)
+                if stop_loop:
+                    break
+            task.cancel()
+
+        asyncio.run(read_info())
+
+    th = threading.Thread(target=func)
+    th.start()
+
+    ttime.sleep(1)
+
+    assert ac_manager.is_user_known("tom"), pprint.pformat(ac_manager._user_info)
+    assert ac_manager.get_user_roles("bob") == {"admin", "expert"}
+
+    groups2 = copy.deepcopy(groups)
+    groups2["user"].pop("tom")
+    groups2["admin"].pop("bob")
+    requests.post("http://localhost:60001/test/set_info", json=groups2)
+
+    ttime.sleep(3)
+
+    assert not ac_manager.is_user_known("tom"), pprint.pformat(ac_manager._user_info)
+    assert ac_manager.get_user_roles("bob") == {"expert"}
+
+    stop_loop = True
+    th.join()
+
+
+# fmt: off
+@pytest.mark.parametrize("ac_params, delay", [
+    # Wrong port (fails to connect)
+    ({"port": 60002, "instrument": "TST", "endstation": "default"}, 0),
+    # Wrong instrument
+    ({"port": 60001, "instrument": "NEX", "endstation": "default"}, 0),
+    # Wrong endstation
+    ({"port": 60001, "instrument": "TST", "endstation": "nonexisting"}, 0),
+    # Long response delay (request timeout)
+    ({"port": 60001, "instrument": "TST", "endstation": "default"}, 10),
+])
+# fmt: on
+def test_ServerBasedAPIAccessControl_03(access_api_server, ac_params, delay):
+    """
+    ServerBasedAPIAccessControl: expiration of user access data
+    """
+    groups = user_access_info_to_groups(_user_access_info_1)
+    requests.post("http://localhost:60001/test/set_info", json=groups)
+    if delay:
+        requests.post("http://localhost:60001/test/set_delay", json={"delay": delay})
+
+    ac_manager = ServerBasedAPIAccessControl(
+        server="localhost",
+        update_period=2,
+        expiration_period=3,
+        http_timeout=1,
+        **ac_params,
+    )
+
+    # Set user info (artificially)
+    ac_manager._user_info.update(_user_access_info_1)
+
+    stop_loop = False
+
+    def func():
+        # Read user info from the API server (once)
+        async def read_info():
+            task = asyncio.create_task(ac_manager.background_update_authentication_info())
+            while True:
+                await asyncio.sleep(0.1)
+                if stop_loop:
+                    break
+            task.cancel()
+
+        asyncio.run(read_info())
+
+    th = threading.Thread(target=func)
+    th.start()
+
+    for username in _user_access_info_1:
+        assert ac_manager.is_user_known(username)
+
+    ttime.sleep(5)
+
+    for username in _user_access_info_1:
+        assert not ac_manager.is_user_known(username)
+
+    stop_loop = True
+    th.join()
 
 
 # ====================================================================================

--- a/bluesky_httpserver/tests/test_access_policies.py
+++ b/bluesky_httpserver/tests/test_access_policies.py
@@ -272,7 +272,7 @@ def test_ServerBasedAPIAccessControl_01(access_api_server, n_requests):
     # Read user info from the API server (once)
     async def read_info():
         for _ in range(n_requests):
-            await ac_manager.request_authentication_info()
+            await ac_manager.update_access_info()
 
     asyncio.run(read_info())
 
@@ -313,7 +313,7 @@ def test_ServerBasedAPIAccessControl_02(access_api_server):
     def func():
         # Read user info from the API server (once)
         async def read_info():
-            task = asyncio.create_task(ac_manager.background_update_authentication_info())
+            task = asyncio.create_task(ac_manager._background_updates())
             while True:
                 await asyncio.sleep(0.1)
                 if stop_loop:
@@ -381,7 +381,7 @@ def test_ServerBasedAPIAccessControl_03(access_api_server, ac_params, delay):
     def func():
         # Read user info from the API server (once)
         async def read_info():
-            task = asyncio.create_task(ac_manager.background_update_authentication_info())
+            task = asyncio.create_task(ac_manager._background_updates())
             while True:
                 await asyncio.sleep(0.1)
                 if stop_loop:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -28,7 +28,7 @@ Environment variables for controlling 0MQ communication with Run Engine Manager:
 
 Environment variables for configuring authentication:
 
-- ``QSERVER_HTTP_SERVER_SERVER_SECRET_KEYS`` - the value may be a single key or a ``;``-separated list of keys to 
+- ``QSERVER_HTTP_SERVER_SERVER_SECRET_KEYS`` - the value may be a single key or a ``;``-separated list of keys to
   support key rotation. The first key will be used for encryption. Each key will be tried in turn for decryption.
 
 - ``QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY`` - Single-user API key. Enable single-user mode.
@@ -52,14 +52,14 @@ Environment variables for database configuration:
 
 - ``QSERVER_HTTP_SERVER_DATABASE_POOL_SIZE`` - connection pool size. Default is 5.
 
-- ``QSERVER_HTTP_SERVER_DATABASE_POOL_PRE_PING`` - if true (default), use pessimistic connection testings. 
+- ``QSERVER_HTTP_SERVER_DATABASE_POOL_PRE_PING`` - if true (default), use pessimistic connection testings.
   This is recommended.
 
 Environment variables for customization of the server:
 
-- ``QSERVER_HTTP_CUSTOM_ROUTERS`` - one or multiple custom routers (module names) separated with ``:`` or ``,``. 
+- ``QSERVER_HTTP_CUSTOM_ROUTERS`` - one or multiple custom routers (module names) separated with ``:`` or ``,``.
 
-- ``QSERVER_CUSTOM_MODULES`` - THE FUNCTIONALITY WILL BE DEPRECATED IN FAVOR OF CUSTOM ROUTERS.  
+- ``QSERVER_CUSTOM_MODULES`` - THE FUNCTIONALITY WILL BE DEPRECATED IN FAVOR OF CUSTOM ROUTERS.
 
 
 Configuration Files
@@ -78,12 +78,12 @@ HTTP Server is communicating with Run Engine (RE) Manager over 0MQ. The default 
 configuration assumes that RE Manager is running on ``localhost`` and port 60615 is used
 for control channel (REQ-REP), the console output is published using port 60625 (PUB-SUB),
 and encryption for control channel is disabled. The default settings allow Queue Server to
-run 'out of the box' if all system components are running on the same machine, which 
+run 'out of the box' if all system components are running on the same machine, which
 is the case in testing and simple demos. In practical deployments the settings need to be
 customized.
 
-The configuration for 0MQ communication with RE Manager can be customized using environment 
-variables or configuration files. 
+The configuration for 0MQ communication with RE Manager can be customized using environment
+variables or configuration files.
 
 The following environment variables are used to configure 0MQ communication settings:
 
@@ -93,11 +93,11 @@ The following environment variables are used to configure 0MQ communication sett
 - ``QSERVER_ZMQ_INFO_ADDRESS`` - the address of PUB-SUB 0MQ socket used by RE Manager
   to publish console output. The default address: ``tcp://localhost:60625``.
 
-- ``QSERVER_ZMQ_PUBLIC_KEY`` - the public key used for encryption of control messages 
+- ``QSERVER_ZMQ_PUBLIC_KEY`` - the public key used for encryption of control messages
   sent to RE Manager over 0MQ. The encryption is disabled by default. To enable the encryption,
-  generate the public/private key pair using 
-  `'qserver-zmq-keys' CLI tool <https://blueskyproject.io/bluesky-queueserver/cli_tools.html#qserver-zmq-keys>`_, 
-  pass the private key to RE Manager. Pass the public key to HTTP Server using 
+  generate the public/private key pair using
+  `'qserver-zmq-keys' CLI tool <https://blueskyproject.io/bluesky-queueserver/cli_tools.html#qserver-zmq-keys>`_,
+  pass the private key to RE Manager. Pass the public key to HTTP Server using
   ``QSERVER_ZMQ_PUBLIC_KEY`` environment variable.
 
 The same parameters can be specified by including ``qserver_zmq_configuration`` into
@@ -108,7 +108,7 @@ the config file::
     info_address: tcp://localhost:60625
     public_key: ${PUBLIC_KEY}
 
-All parameters in the config file are optional and override the values passed using 
+All parameters in the config file are optional and override the values passed using
 environment variables and the default values. The public key is typically passed using environment
 variable ``QSERVER_ZMQ_PUBLIC_KEY``, but different environment variable name could be specified
 in the config file as in the example above. Explicitly including public key in the config file
@@ -118,7 +118,7 @@ Custom Routers
 **************
 
 The HTTP Server can be extended to support application-specific functionality by developing
-Python modules with custom routers. The module names are passed to the server as ``:``-separated 
+Python modules with custom routers. The module names are passed to the server as ``:``-separated
 list using the environment variable ``QSERVER_HTTP_CUSTOM_ROUTERS``::
 
   export QSERVER_HTTP_CUSTOM_ROUTERS modu.le1:mod.ule2
@@ -148,8 +148,8 @@ Setting Secret Keys
 
 The server is using secret keys for authentication and authorization algorithms.
 If the secret keys are not set in the configuration, the server generates random
-secret keys upon startup and the existing tokens stop working after the restart 
-of the server. This is not acceptable in production deployments, therefore 
+secret keys upon startup and the existing tokens stop working after the restart
+of the server. This is not acceptable in production deployments, therefore
 the server configuration must contain secret keys that do not change between restarts.
 
 The server configuration may contain multiple secret keys (a list of keys).
@@ -166,7 +166,7 @@ the secret key can be set as part of *authentication* parameters in the server c
       - ${SECRET_KEY_2}
 
 It is considered unsafe to keep secret keys in text files, but instead use environment variables
-to list the secret keys. In this example, the environment variables ``SECRET_KEY_1`` and 
+to list the secret keys. In this example, the environment variables ``SECRET_KEY_1`` and
 ``SECRET_KEY_2`` must be set before starting the server.
 
 Secure secret keys may be generated using ``openssl`` or by running a Python script from Linux
@@ -353,7 +353,7 @@ scopes from ``unauthenticated_single_user`` role::
           unauthenticated_public:
             scopes_add: read:console
           unauthenticated_single_user:
-            scipes_remove:
+            scopes_remove:
               - write:scripts
               - user:apikeys
 
@@ -406,6 +406,42 @@ See the documentation on ``DictionaryAPIAccessControl`` for more details.
    :toctree: generated
 
     authorization.DictionaryAPIAccessControl
+
+Access Policy Based on External Access Control Server
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The policy is periodically loading user access data from the external
+Access Control server. The server holds user access information obtained from other
+services, such as Active Directory, and serves the purpose of reducing the load
+on those services.
+
+The following example shows configuration of ``ServerBasedAPIAccessControl``
+to use hypothetical ``accesscontrol.server.com:60001`` as Access Control server.
+The requests are sent with the average period of 300 seconds (+/- 20%). If the server
+can not be contacted for 3600 seconds (1 hour), the access control data expires and
+users lose access to the Queue Server. ::
+
+    api_access:
+      policy: bluesky_httpserver.authorization:ServerBasedAPIAccessControl
+      args:
+        instrument: srx
+        server: accesscontrol.server.com
+        port: 60001
+        update_period: 300
+        expiration_period: 3600
+        roles:
+          expert:
+            scopes_remove:
+              - write:scripts
+              - write:permissions
+
+See the documentation on ``ServerBasedAPIAccessControl`` for more details.
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    authorization.ServerBasedAPIAccessControl
 
 Authorization: Resource Access
 ******************************


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of  `ServerBasedAPIAccessControl` access policy. User access data is periodically downloaded from an Access Control server by calling `/instruments/{instrument}/{endstation}/qserver/access` API. Currently communication to Access Control server is unauthenticated. Authentication can be added in the future

## Description
<!--- Describe your changes in detail -->

See documentation for details.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Access Control server is intended to reduce load to central services such as Active Directory.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

Implementation of  `ServerBasedAPIAccessControl` access policy.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests are implemented.

<!--
## Screenshots (if appropriate):
-->
