### PR TITLE
Modifications to 'ServerBasedAPIAccessControl' Policy

### DIFF
--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -486,10 +486,9 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
     Access policy based on external Access Control Server. The user access data is
     periodically requested from the server using REST API. The access control server is
     expected to expose ``/instrument/{instrument}/qserver/access`` API,
-    where ``instrument`` and ``endstation`` are the identifiers of the instrument and
-    endstation (optional) passed as class constructor parameters. The API is expected to
-    return a dictionary which maps roles ('admin', 'expert', 'advanced', 'user', 'observer')
-    to dictionaries with information on users that are assigned the role, for example
+    where ``instrument`` is the lowercase name of the instrument passed to the class constructor.
+    The API is expected to return a dictionary which maps roles ('admin', 'expert', 'advanced', 'user',
+    'observer') to dictionaries with information on users that are assigned the role, for example
 
     .. code-block::
 
@@ -579,7 +578,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
             msg = err.args[0]
             raise ConfigError(f"ValidationError while validating parameters BasicAPIAccessControl: {msg}") from err
 
-        self._instrument = instrument
+        self._instrument = instrument.lower()
 
         self._server = server
         self._port = port
@@ -598,7 +597,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         Send a single request to the API server and update locally stored access control info.
         """
         base_url = f"http://{self._server}:{self._port}"
-        access_api = f"/instrument/{self._instrument}/qserver/access"
+        access_api = f"/instrument/{self._instrument.lower()}/qserver/access"
         async with httpx.AsyncClient(base_url=base_url, timeout=self._http_timeout) as client:
             response = await client.get(access_api)
             response.raise_for_status()

--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -620,7 +620,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
                             if first_name or last_name:
                                 displayed_name = first_name + last_name
                                 user_info[u].setdefault("displayed_name", displayed_name)
-                        if "email" in ui:
+                        if ("email" in ui) and ui["email"] and isinstance(ui["email"], str):
                             user_info[u].setdefault("email", ui["email"])
                 else:
                     logger.error("Unsupported role %r. Supported roles: %s", g, list(self._roles.keys()))

--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -302,16 +302,16 @@ class BasicAPIAccessControl:
             Formatted displayed user name.
         """
         user_info = self._collect_user_info(username)
-        mail = user_info.get("mail", None)
+        email = user_info.get("email", None)
         displayed_name = user_info.get("displayed_name", None)
-        if not mail and not displayed_name:
+        if not email and not displayed_name:
             return username
         elif not displayed_name:
-            return f"{username} <{mail}>"
-        elif not mail:
+            return f"{username} <{email}>"
+        elif not email:
             return f'{username} "{displayed_name}"'
         else:
-            return f'{username} "{displayed_name} <{mail}>"'
+            return f'{username} "{displayed_name} <{email}>"'
 
     def get_user_info(self, username):
         """
@@ -366,7 +366,7 @@ properties:
                       - type: string
                         pattern: "^.+$"
                       - type: "null"
-                  mail:
+                  email:
                     oneOf:
                       - type: string
                         pattern: "^.+@.+$"
@@ -412,11 +412,11 @@ class DictionaryAPIAccessControl(BasicAPIAccessControl):
                 roles:
                   - admin
                   - expert
-                mail: bob@gmail.com
+                email: bob@gmail.com
               jdoe:
                 roles: advanced
                 dislayed_name: Doe, John
-                mail: jdoe@gmail.com
+                email: jdoe@gmail.com
 
     The policy arguments may also include ``roles`` parameter, which is handled by ``BasicAPIAccessControl``.
     See docstring for ``BasicAPIAccessControl`` for more detailed information.
@@ -466,8 +466,6 @@ additionalProperties: false
 properties:
   instrument:
     type: string
-  endstation:
-    type: string
   roles:  # Detailed validation is performed elsewhere
     description: The value is passed to BasicAPIAccessControl object
   server:
@@ -487,7 +485,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
     """
     Access policy based on external Access Control Server. The user access data is
     periodically requested from the server using REST API. The access control server is
-    expected to expose ``/instruments/{instrument}/{endstation}/qserver/access`` API,
+    expected to expose ``/instrument/{instrument}/qserver/access`` API,
     where ``instrument`` and ``endstation`` are the identifiers of the instrument and
     endstation (optional) passed as class constructor parameters. The API is expected to
     return a dictionary which maps roles ('admin', 'expert', 'advanced', 'user', 'observer')
@@ -497,21 +495,21 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
 
         {
             "admin": {
-                "bob": {"mail": "bob@gmail.com"},
+                "bob": {"email": "bob@gmail.com"},
                 "tom": {},
             },
             "expert": {
-                "bob": {"mail": "bob@gmail.com"}
+                "bob": {"email": "bob@gmail.com"}
             },
             "advanced": {
-                "jdoe": {"mail": "jdoe@gmail.com", "displayed_name": "Doe, John"}
+                "jdoe": {"email": "jdoe@gmail.com", "first_name": "John", "last_name": "Doe"}
             },
             "user": {},
             "observer": {},
         }
 
     User information consists of the username (dictionary key, which makes it mandatory) and
-    optional ``'mail'`` and ``'displayed_name'``. Additional user information is ignored.
+    optional ``'email'`` and ``'displayed_name'``. Additional user information is ignored.
 
     Access information is requested from the server at startup and periodically updated
     during operation with the period ``update_period +/-20%``. If the server is not accessible,
@@ -527,8 +525,6 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
     ----------
     instrument: str
         Instrument ID, such as 'SRX' or 'TES'. This is the required parameter.
-    endstation: str, optional
-        Endstation ID (if applicable). The default value is ``'default'``.
     roles: dict or None, optional
         The dictionary that defines new and/or modifies existing roles. The dictionary
         is passed to the ``BasicAPIAccessControl`` constructor. Default: ``None``.
@@ -555,7 +551,6 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         self,
         *,
         instrument=None,
-        endstation="default",
         roles=None,
         server="localhost",
         port=8000,
@@ -571,7 +566,6 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         try:
             config = {
                 "instrument": instrument,
-                "endstation": endstation,
                 "roles": roles,
                 "server": server,
                 "port": port,
@@ -586,7 +580,6 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
             raise ConfigError(f"ValidationError while validating parameters BasicAPIAccessControl: {msg}") from err
 
         self._instrument = instrument
-        self._endstation = endstation
 
         self._server = server
         self._port = port
@@ -605,7 +598,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         Send a single request to the API server and update locally stored access control info.
         """
         base_url = f"http://{self._server}:{self._port}"
-        access_api = f"/instruments/{self._instrument}/{self._endstation}/qserver/access"
+        access_api = f"/instrument/{self._instrument}/qserver/access"
         async with httpx.AsyncClient(base_url=base_url, timeout=self._http_timeout) as client:
             response = await client.get(access_api)
             response.raise_for_status()
@@ -617,10 +610,19 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
                     for u, ui in gmembers.items():
                         user_info.setdefault(u, {})
                         user_info[u].setdefault("roles", []).append(g)
-                        if "displayed_name" in ui:
-                            user_info[u].setdefault("displayed_name", ui["displayed_name"])
-                        if "mail" in ui:
-                            user_info[u].setdefault("mail", ui["mail"])
+                        if ("first_name" in ui) or ("last_name" in ui):
+                            first_name = ui.get("first_name", "") or ""
+                            first_name = first_name if isinstance(first_name, str) else ""
+                            last_name = ui.get("last_name", "") or ""
+                            last_name = last_name if isinstance(last_name, str) else ""
+                            first_name, last_name = first_name.strip(), last_name.strip()
+                            if first_name and last_name:
+                                last_name = " " + last_name
+                            if first_name or last_name:
+                                displayed_name = first_name + last_name
+                                user_info[u].setdefault("displayed_name", displayed_name)
+                        if "email" in ui:
+                            user_info[u].setdefault("email", ui["email"])
                 else:
                     logger.error("Unsupported role %r. Supported roles: %s", g, list(self._roles.keys()))
 

--- a/bluesky_httpserver/tests/access_api_server/api_server.py
+++ b/bluesky_httpserver/tests/access_api_server/api_server.py
@@ -20,7 +20,6 @@ _access_info = {
 }
 
 _instrument = "tst"
-_endstation = "default"
 
 _delay = 0
 
@@ -32,19 +31,17 @@ async def startup_event():
     logger.info("Access API Server started successfully.")
 
 
-def _get_qserver_group_members(*, beamline, endstation):
+def _get_qserver_group_members(*, beamline):
     return _access_info
 
 
-@router.get("/instruments/{instrument}/{endstation}/qserver/access")
-async def get_access_info(instrument: str, endstation: str):
+@router.get("/instrument/{instrument}/qserver/access")
+async def get_access_info(instrument: str):
     # The delay is intended for testing timeouts.
     await asyncio.sleep(_delay)
     if instrument != _instrument:
         raise HTTPException(status_code=406, detail=f"Unknown instrument: {instrument!r}")
-    if endstation != _endstation:
-        raise HTTPException(status_code=406, detail=f"Unknown endstation: {endstation!r}")
-    return _get_qserver_group_members(beamline=instrument, endstation=endstation)
+    return _get_qserver_group_members(beamline=instrument)
 
 
 # ================================================================================
@@ -61,12 +58,6 @@ async def _set_info(access_info: dict):
 async def _set_instrument(instrument: dict):
     global _instrument
     _instrument = copy.deepcopy(instrument)
-
-
-@router.post("/test/set_endstation")
-async def _set_endstation(endstation: dict):
-    global _endstation
-    _endstation = copy.deepcopy(endstation)
 
 
 @router.post("/test/set_delay")

--- a/bluesky_httpserver/tests/test_access_policies.py
+++ b/bluesky_httpserver/tests/test_access_policies.py
@@ -271,6 +271,9 @@ _user_access_info_2 = {
     "user8": {"roles": ["user"], "first_name": "User", "last_name": None},
     "user9": {"roles": ["user"], "first_name": None, "last_name": None},
     "user10": {"roles": ["user"], "first_name": 10, "last_name": [1, 2, 3]},
+    "user11": {"roles": ["user"], "email": None},
+    "user12": {"roles": ["user"], "email": ""},
+    "user13": {"roles": ["user"], "email": 10},
 }
 
 
@@ -285,6 +288,9 @@ _user_access_info_2_displayed_names = {
     "user8": {"roles": ["user"], "displayed_name": "User"},
     "user9": {"roles": ["user"]},
     "user10": {"roles": ["user"]},
+    "user11": {"roles": ["user"]},
+    "user12": {"roles": ["user"]},
+    "user13": {"roles": ["user"]},
 }
 
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -393,11 +393,11 @@ for two users (``bob`` and ``jdoe`` are login usernames)::
             roles:
               - admin
               - expert
-            mail: bob@gmail.com
+            email: bob@gmail.com
           jdoe:
             roles: advanced
             dislayed_name: Doe, John
-            mail: jdoe@gmail.com
+            email: jdoe@gmail.com
 
 See the documentation on ``DictionaryAPIAccessControl`` for more details.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Some additional modifications to 'ServerBasedAPIAccessControl' access policy. The PR is continuation of https://github.com/bluesky/bluesky-httpserver/pull/47 The changes include:

- User's email is provided in the dictionary with user access information using the key `email` instead of `mail`.
- User access information provided by the external API server now contains `last_name` and `first_name` keys instead of `displayed_name`. The displayed name is generated based on the first and last name of the user.
- `ServerBasedAPIAccessControl` policy is now calling `/instrument/{instrument}/qserver/access` instead of `/instruments/{instrument}/{endstation}/qserver/access`. `ServerBasedAPIAccessControl` policy does not accept the parameter `endstation`.

`ServerBasedAPIAccessControl` is not contained in the released version of the server. The changes are unlikely to influence any existing deployments.