### PR TITLE
New API: /config/get and /queue/autostart

### DIFF
--- a/bluesky_httpserver/routers/core_api.py
+++ b/bluesky_httpserver/routers/core_api.py
@@ -57,7 +57,7 @@ async def status_handler(
 
 
 @router.post("/queue/autostart")
-async def queue_mode_set_handler(
+async def queue_autostart_handler(
     payload: dict,
     principal=Security(get_current_principal, scopes=["write:queue:control"]),
 ):

--- a/bluesky_httpserver/routers/core_api.py
+++ b/bluesky_httpserver/routers/core_api.py
@@ -56,6 +56,21 @@ async def status_handler(
     return msg
 
 
+@router.post("/queue/autostart")
+async def queue_mode_set_handler(
+    payload: dict,
+    principal=Security(get_current_principal, scopes=["write:queue:control"]),
+):
+    """
+    Set queue mode.
+    """
+    try:
+        msg = await SR.RM.queue_autostart(**payload)
+    except Exception:
+        process_exception()
+    return msg
+
+
 @router.post("/queue/mode/set")
 async def queue_mode_set_handler(
     payload: dict,

--- a/bluesky_httpserver/routers/core_api.py
+++ b/bluesky_httpserver/routers/core_api.py
@@ -56,6 +56,21 @@ async def status_handler(
     return msg
 
 
+@router.get("/config/get")
+async def queue_config_get(
+    payload: dict = {},
+    principal=Security(get_current_principal, scopes=["read:config"]),
+):
+    """
+    Get manager configuration.
+    """
+    try:
+        msg = await SR.RM.config_get(**payload)
+    except Exception:
+        process_exception()
+    return msg
+
+
 @router.post("/queue/autostart")
 async def queue_autostart_handler(
     payload: dict,

--- a/bluesky_httpserver/tests/test_core_api_main.py
+++ b/bluesky_httpserver/tests/test_core_api_main.py
@@ -4,7 +4,7 @@ import re
 import time as ttime
 
 import pytest
-from bluesky_queueserver.manager.profile_ops import gen_list_of_plans_and_devices
+from bluesky_queueserver import gen_list_of_plans_and_devices
 from bluesky_queueserver.manager.tests.common import (  # noqa F401
     append_code_to_last_startup_file,
     copy_default_profile_collection,
@@ -58,6 +58,26 @@ def test_http_server_status_handler(re_manager, fastapi_server):  # noqa F811
     assert resp["items_in_queue"] == 0
     assert resp["running_item_uid"] is None
     assert resp["worker_environment_exists"] is False
+
+
+def test_http_server_queue_autostart_handler_1(re_manager, fastapi_server):  # noqa F811
+    """
+    Basic tests for ``queue_autostart`` API
+    """
+    status = request_to_json("get", "/status")
+    assert status["queue_autostart_enabled"] is False
+
+    resp1 = request_to_json("post", "/queue/autostart", json={"enable": True})
+    assert resp1["success"] is True
+    assert resp1["msg"] == ""
+    status = request_to_json("get", "/status")
+    assert status["queue_autostart_enabled"] is True
+
+    resp2 = request_to_json("post", "/queue/autostart", json={"enable": False})
+    assert resp2["success"] is True
+    assert resp2["msg"] == ""
+    status = request_to_json("get", "/status")
+    assert status["queue_autostart_enabled"] is False
 
 
 def test_http_server_queue_mode_set_handler_1(re_manager, fastapi_server):  # noqa F811

--- a/bluesky_httpserver/tests/test_core_api_main.py
+++ b/bluesky_httpserver/tests/test_core_api_main.py
@@ -60,6 +60,16 @@ def test_http_server_status_handler(re_manager, fastapi_server):  # noqa F811
     assert resp["worker_environment_exists"] is False
 
 
+def test_http_server_config_get_handler(re_manager, fastapi_server):  # noqa F811
+    resp = request_to_json("get", "/config/get")
+    assert resp["success"] is True, pprint.pformat(resp)
+    assert resp["msg"] == "", pprint.pformat(resp)
+    assert "config" in resp, pprint.pformat(resp)
+    assert "ip_connect_info" in resp["config"], pprint.pformat(resp)
+    # Kernel does not exist, so connect info is {}
+    assert resp["config"]["ip_connect_info"] == {}
+
+
 def test_http_server_queue_autostart_handler_1(re_manager, fastapi_server):  # noqa F811
     """
     Basic tests for ``queue_autostart`` API


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

New API were added to bring the package up-to-date with the Queue Server:

- `/config/get` API
- `/queue/autostart` API

This PR should be merged with https://github.com/bluesky/bluesky-queueserver-api/pull/41

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add new API that already exist in the Queue Server, but not supported by this package.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- New API: `/config/get` and `/queue/autostart`

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added.

<!--
## Screenshots (if appropriate):
-->
