### PR TITLE
Compatibility with Pydantic 2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-      include:
-        - pydatic-version: "<2.0.0"
-          fastapi-version: "<0.100.0"
-        - pydatic-version: ">=2.0.0"
-          fastapi-version: ">=0.100.0"
+        include:
+          - pydatic-version: "<2.0.0"
+            fastapi-version: "<0.100.0"
+          - pydatic-version: ">=2.0.0"
+            fastapi-version: ">=0.100.0"
       fail-fast: false
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        pydantic-version: [1, 2]
+      include:
+        - pydatic-version: "<2.0.0"
+          fastapi-version: "<0.100.0"
+        - pydatic-version: ">=2.0.0"
+          fastapi-version: ">=0.100.0"
       fail-fast: false
 
     steps:
@@ -44,8 +48,8 @@ jobs:
 
         pip install .
         pip install -r requirements-dev.txt
-        pip install pydantic==${{ matrix.pydantic-version }}
-        
+        pip install pydantic${{ matrix.pydantic-version }} fastapi${{ matrix.fastapi-version }}
+
         pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        pydantic-version: [1, 2]
       fail-fast: false
 
     steps:
@@ -43,6 +44,8 @@ jobs:
 
         pip install .
         pip install -r requirements-dev.txt
+        pip install pydantic==${{ matrix.pydantic-version }}
+        
         pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,11 +10,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         pydantic-version: ["<2.0.0", ">=2.0.0"]
-        include:
-          - pydatic-version: "<2.0.0"
-            fastapi-version: "<0.100.0"
-          - pydatic-version: ">=2.0.0"
-            fastapi-version: ">=0.100.0"
       fail-fast: false
 
     steps:
@@ -50,7 +45,7 @@ jobs:
         pip install --upgrade pip
         pip install .
         pip install -r requirements-dev.txt
-        pip install "pydantic${{ matrix.pydantic-version }}" "fastapi${{ matrix.fastapi-version }}"
+        pip install "pydantic${{ matrix.pydantic-version }}"
 
         pip list
     - name: Test with pytest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        pydantic-version: ["<2.0.0", ">=2.0.0"]
         include:
           - pydatic-version: "<2.0.0"
             fastapi-version: "<0.100.0"
@@ -46,9 +47,10 @@ jobs:
         pip install .
         popd
 
+        pip install --upgrade pip
         pip install .
         pip install -r requirements-dev.txt
-        pip install pydantic${{ matrix.pydantic-version }} fastapi${{ matrix.fastapi-version }}
+        pip install "pydantic${{ matrix.pydantic-version }}" "fastapi${{ matrix.fastapi-version }}"
 
         pip list
     - name: Test with pytest

--- a/2
+++ b/2
@@ -1,0 +1,3 @@
+Requirement already satisfied: pydantic in /home/dgavrilov/miniconda3/envs/bs-qserver-dev/lib/python3.10/site-packages (1.0)
+Requirement already satisfied: fastapi in /home/dgavrilov/miniconda3/envs/bs-qserver-dev/lib/python3.10/site-packages (0.65.0)
+Requirement already satisfied: starlette==0.14.2 in /home/dgavrilov/miniconda3/envs/bs-qserver-dev/lib/python3.10/site-packages (from fastapi) (0.14.2)

--- a/bluesky_httpserver/authentication.py
+++ b/bluesky_httpserver/authentication.py
@@ -21,7 +21,16 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from jose import ExpiredSignatureError, JWTError, jwt
 
-from pydantic import BaseModel, BaseSettings
+import pydantic
+from pydantic import BaseModel
+from packaging import version
+
+
+if version.parse(pydantic.__version__) < version.parse("2.0.0"):
+    from pydantic import BaseSettings
+else:
+    from pydantic_settings import BaseSettings
+
 
 from . import schemas
 from .authorization._defaults import _DEFAULT_ANONYMOUS_PROVIDER_NAME

--- a/bluesky_httpserver/authentication.py
+++ b/bluesky_httpserver/authentication.py
@@ -22,15 +22,13 @@ with warnings.catch_warnings():
     from jose import ExpiredSignatureError, JWTError, jwt
 
 import pydantic
-from pydantic import BaseModel
 from packaging import version
-
+from pydantic import BaseModel
 
 if version.parse(pydantic.__version__) < version.parse("2.0.0"):
     from pydantic import BaseSettings
 else:
     from pydantic_settings import BaseSettings
-
 
 from . import schemas
 from .authorization._defaults import _DEFAULT_ANONYMOUS_PROVIDER_NAME

--- a/bluesky_httpserver/routers/core_api.py
+++ b/bluesky_httpserver/routers/core_api.py
@@ -4,17 +4,15 @@ import logging
 import pprint
 from typing import Optional
 
+import pydantic
 from bluesky_queueserver.manager.conversions import simplify_plan_descriptions, spreadsheet_to_plan_list
 from fastapi import APIRouter, Depends, File, Form, Request, Security, UploadFile
-
 from packaging import version
-import pydantic
 
 if version.parse(pydantic.__version__) < version.parse("2.0.0"):
     from pydantic import BaseSettings
 else:
     from pydantic_settings import BaseSettings
-
 
 from ..authentication import get_current_principal
 from ..console_output import ConsoleOutputEventStream, StreamingResponseFromClass

--- a/bluesky_httpserver/routers/core_api.py
+++ b/bluesky_httpserver/routers/core_api.py
@@ -6,7 +6,15 @@ from typing import Optional
 
 from bluesky_queueserver.manager.conversions import simplify_plan_descriptions, spreadsheet_to_plan_list
 from fastapi import APIRouter, Depends, File, Form, Request, Security, UploadFile
-from pydantic import BaseSettings
+
+from packaging import version
+import pydantic
+
+if version.parse(pydantic.__version__) < version.parse("2.0.0"):
+    from pydantic import BaseSettings
+else:
+    from pydantic_settings import BaseSettings
+
 
 from ..authentication import get_current_principal
 from ..console_output import ConsoleOutputEventStream, StreamingResponseFromClass

--- a/bluesky_httpserver/schemas.py
+++ b/bluesky_httpserver/schemas.py
@@ -3,10 +3,10 @@ import uuid
 from datetime import datetime
 from typing import Dict, Generic, List, Optional, TypeVar, Union
 
-from packaging import version
 import pydantic
 import pydantic.dataclasses
 import pydantic.generics
+from packaging import version
 
 # from ..structures.core import StructureFamily
 

--- a/bluesky_httpserver/settings.py
+++ b/bluesky_httpserver/settings.py
@@ -4,8 +4,13 @@ import secrets
 from datetime import timedelta
 from functools import lru_cache
 from typing import Any, List, Optional
+from packaging import version
+import pydantic
 
-from pydantic import BaseSettings
+if version.parse(pydantic.__version__) < version.parse("2.0.0"):
+    from pydantic import BaseSettings
+else:
+    from pydantic_settings import BaseSettings
 
 DatabaseSettings = collections.namedtuple("DatabaseSettings", "uri pool_size pool_pre_ping")
 
@@ -16,11 +21,11 @@ class Settings(BaseSettings):
     allow_origins: List[str] = [
         item for item in os.getenv("QSERVER_HTTP_SERVER_ALLOW_ORIGINS", "").split() if item
     ]
-    authentication_provider_names = []  # The list of authentication provider names
+    authentication_provider_names: List[str] = []  # The list of authentication provider names
     authenticator: Any = None
     # These 'single user' settings are only applicable if authenticator is None.
-    single_user_api_key = os.getenv("QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY", secrets.token_hex(32))
-    single_user_api_key_generated = not ("QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY" in os.environ)
+    single_user_api_key: str = os.getenv("QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY", secrets.token_hex(32))
+    single_user_api_key_generated: bool = not ("QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY" in os.environ)
     # The QSERVER_HTTP_SERVER_SERVER_SECRET_KEYS may be a single key or a ;-separated list of
     # keys to support key rotation. The first key will be used for encryption. Each
     # key will be tried in turn for decryption.
@@ -37,7 +42,7 @@ class Settings(BaseSettings):
     # Put a fairly low limit on the maximum size of one chunk, keeping in mind
     # that data should generally be chunked. When we implement async responses,
     # we can raise this global limit.
-    response_bytesize_limit = int(os.getenv("QSERVER_HTTP_SERVER_RESPONSE_BYTESIZE_LIMIT", 300_000_000))  # 300 MB
+    response_bytesize_limit: int = int(os.getenv("QSERVER_HTTP_SERVER_RESPONSE_BYTESIZE_LIMIT", 300_000_000))  # 300 MB
     database_uri: Optional[str] = os.getenv("QSERVER_HTTP_SERVER_DATABASE_URI")
     database_pool_size: Optional[int] = int(os.getenv("QSERVER_HTTP_SERVER_DATABASE_POOL_SIZE", 5))
     database_pool_pre_ping: Optional[bool] = bool(int(os.getenv("QSERVER_HTTP_SERVER_DATABASE_POOL_PRE_PING", 1)))

--- a/bluesky_httpserver/settings.py
+++ b/bluesky_httpserver/settings.py
@@ -4,8 +4,9 @@ import secrets
 from datetime import timedelta
 from functools import lru_cache
 from typing import Any, List, Optional
-from packaging import version
+
 import pydantic
+from packaging import version
 
 if version.parse(pydantic.__version__) < version.parse("2.0.0"):
     from pydantic import BaseSettings
@@ -42,7 +43,9 @@ class Settings(BaseSettings):
     # Put a fairly low limit on the maximum size of one chunk, keeping in mind
     # that data should generally be chunked. When we implement async responses,
     # we can raise this global limit.
-    response_bytesize_limit: int = int(os.getenv("QSERVER_HTTP_SERVER_RESPONSE_BYTESIZE_LIMIT", 300_000_000))  # 300 MB
+    response_bytesize_limit: int = int(
+        os.getenv("QSERVER_HTTP_SERVER_RESPONSE_BYTESIZE_LIMIT", 300_000_000)
+    )  # 300 MB
     database_uri: Optional[str] = os.getenv("QSERVER_HTTP_SERVER_DATABASE_URI")
     database_pool_size: Optional[int] = int(os.getenv("QSERVER_HTTP_SERVER_DATABASE_POOL_SIZE", 5))
     database_pool_pre_ping: Optional[bool] = bool(int(os.getenv("QSERVER_HTTP_SERVER_DATABASE_POOL_PRE_PING", 1)))

--- a/v2
+++ b/v2
@@ -1,0 +1,3 @@
+Requirement already satisfied: pydantic in /home/dgavrilov/miniconda3/envs/bs-qserver-dev/lib/python3.10/site-packages (1.0)
+Requirement already satisfied: fastapi in /home/dgavrilov/miniconda3/envs/bs-qserver-dev/lib/python3.10/site-packages (0.65.0)
+Requirement already satisfied: starlette==0.14.2 in /home/dgavrilov/miniconda3/envs/bs-qserver-dev/lib/python3.10/site-packages (from fastapi) (0.14.2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Minor changes to make the code compatible with Pydantic 2. 

The server still works with Pydantic 1. The respective code will be removed once Pydantic 1 becomes obsolete.

Addresses the issue https://github.com/bluesky/bluesky-httpserver/issues/56

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

- The server is compatible with Pydantic v1 and v2 (recently released).

### Added

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test matrix includes tests with Pydantic v1 and v2.

<!--
## Screenshots (if appropriate):
-->
