### PR TITLE
Support email usernames in API access validation

### DIFF
--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -25,7 +25,7 @@ properties:
       - type: object
         additionalProperties: false
         patternProperties:
-          "^[a-zA-Z_][0-9a-zA-Z_]*$":
+          "^[a-zA-Z_][0-9a-zA-Z_.@]*$":
             oneOf:
               - type: object
                 additionalProperties: false
@@ -348,7 +348,7 @@ properties:
       - type: object
         additionalProperties: false
         patternProperties:
-          "^[0-9a-zA-Z_]+$":
+          "^[0-9a-zA-Z_.@]+$":
             oneOf:
               - type: object
                 additionalProperties: false

--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -25,7 +25,7 @@ properties:
       - type: object
         additionalProperties: false
         patternProperties:
-          "^[a-zA-Z_][0-9a-zA-Z_.@]*$":
+          "^[a-zA-Z_][0-9a-zA-Z_.@\\\\-\\\\+]*$":
             oneOf:
               - type: object
                 additionalProperties: false
@@ -348,7 +348,7 @@ properties:
       - type: object
         additionalProperties: false
         patternProperties:
-          "^[0-9a-zA-Z_.@]+$":
+          "^[0-9a-zA-Z_.@\\\\-\\\\+]+$":
             oneOf:
               - type: object
                 additionalProperties: false


### PR DESCRIPTION
Change the JSON schema to accept `.`, `@`, `-`, and `+`, in usernames.

## Description
In our LDAP implementation, our email address can be used in the place of the username, and that includes both `.` and `@` in them. Of course, an email can have other symbols still, but those two cover the vast majority of cases already.

So, to use `DictionaryAPIAccessControl` authorization together with our LDAP-based authentication, this change is welcome. Also, I can't see how accepting those characters could be an issue, though I know next to nothing about that stuff, so please boop me if I'm wrong :slightly_smiling_face: 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Added
Added `.`, `@`, `-`, and `+`, to the allowed character list of `BasicAPIAccessControl` and `DictionaryAPIAccessControl` username validations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

We tested this change in our local test deploy of HTTP server, and after those changes, we managed to successfully authenticate a user using their email address.

<!--
## Screenshots (if appropriate):
-->
