### PR TITLE
Add support for 0MQ encoding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
       fail-fast: false
 
     steps:

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
       fail-fast: false
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
 
     steps:
-    # - uses: docker-practice/actions-setup-docker@master
-    #   timeout-minutes: 12
     - name: Checkout
       uses: actions/checkout@v4
     - name: Fetch tags

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
 
     steps:
+    - uses: docker-practice/actions-setup-docker@master
+      timeout-minutes: 12
     - name: Checkout
       uses: actions/checkout@v4
     - name: Fetch tags
@@ -31,7 +33,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt install docker
         sudo apt install redis
 
         # Start LDAP

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        pydantic-version: ["<2.0.0", ">=2.0.0"]
-        exclude:
-          - python-version: "3.9"
-            pydantic-version: "<2.0.0"
-          - python-version: "3.11"
-            pydantic-version: "<2.0.0"
-          - python-version: "3.12"
-            pydantic-version: "<2.0.0"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # pydantic-version: ["<2.0.0", ">=2.0.0"]
+        # exclude:
+        #   - python-version: "3.9"
+        #     pydantic-version: "<2.0.0"
+        #   - python-version: "3.11"
+        #     pydantic-version: "<2.0.0"
+        #   - python-version: "3.12"
+        #     pydantic-version: "<2.0.0"
 
       fail-fast: false
 
@@ -31,6 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt install docker
         sudo apt install redis
 
         # Start LDAP
@@ -56,8 +57,8 @@ jobs:
         pip install --upgrade pip
         pip install .
         pip install -r requirements-dev.txt
-        pip install "pydantic${{ matrix.pydantic-version }}"
-        pip install bluesky==1.11.0
+        # pip install "pydantic${{ matrix.pydantic-version }}"
+        # pip install bluesky==1.11.0
 
         pip list
     - name: Test with pytest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: docker-practice/actions-setup-docker@master
-      timeout-minutes: 12
+    # - uses: docker-practice/actions-setup-docker@master
+    #   timeout-minutes: 12
     - name: Checkout
       uses: actions/checkout@v4
     - name: Fetch tags

--- a/bluesky_httpserver/app.py
+++ b/bluesky_httpserver/app.py
@@ -307,9 +307,12 @@ def build_app(authentication=None, api_access=None, resource_access=None, server
                     "QSERVER_ZMQ_INFO_ADDRESS to pass address of 0MQ information socket to HTTP Server."
                 )
 
+        zmq_encoding = os.getenv("QSERVER_ZMQ_ENCODING", None)
+
         # Check if ZMQ setting were specified in config file. Overrid the parameters from EVs.
         zmq_control_addr = server_settings["qserver_zmq_configuration"].get("control_address", zmq_control_addr)
         zmq_info_addr = server_settings["qserver_zmq_configuration"].get("info_address", zmq_info_addr)
+        zmq_encoding = server_settings["qserver_zmq_configuration"].get("encoding", zmq_encoding)
 
         # Read public key from the environment variable or config file.
         zmq_public_key = os.environ.get("QSERVER_ZMQ_PUBLIC_KEY", None)
@@ -323,12 +326,13 @@ def build_app(authentication=None, api_access=None, resource_access=None, server
 
         logger.info(
             f"Connecting to RE Manager: \nControl 0MQ socket address: {zmq_control_addr}\n"
-            f"Information 0MQ socket address: {zmq_info_addr}"
+            f"Information 0MQ socket address: {zmq_info_addr}. Encoding: {zmq_encoding!r}\n"
         )
 
         RM = REManagerAPI(
             zmq_control_addr=zmq_control_addr,
             zmq_info_addr=zmq_info_addr,
+            zmq_encoding=zmq_encoding,
             zmq_public_key=zmq_public_key,
             request_fail_exceptions=False,
             status_expiration_period=0.4,  # Make it smaller than default

--- a/bluesky_httpserver/config_schemas/service_configuration.yml
+++ b/bluesky_httpserver/config_schemas/service_configuration.yml
@@ -29,6 +29,10 @@ properties:
           The address of 0MQ info (PUB-SUB) socket of RE Manager, used to publish console output
           e.g. tcp://localhost:60625. Overrides the address set using QSERVER_ZMQ_INFO_ADDRESS
           environment variable
+      encoding:
+        type: string
+        description: |
+          The encoding for 0MQ messages. Supported values: 'json' (default) and 'msgpack'.
       public_key:
         type: string
         description: |

--- a/bluesky_httpserver/database/migrations/versions/722ff4e4fcc7_add_write_scopes_to_default_roles.py
+++ b/bluesky_httpserver/database/migrations/versions/722ff4e4fcc7_add_write_scopes_to_default_roles.py
@@ -1,4 +1,4 @@
-""""Add write scopes to default Roles."
+""" "Add write scopes to default Roles."
 
 Revision ID: 722ff4e4fcc7
 Revises: 481830dd6c11

--- a/bluesky_httpserver/schemas.py
+++ b/bluesky_httpserver/schemas.py
@@ -144,6 +144,7 @@ class NodeMeta(pydantic.BaseModel):
 
 class Resource(generic_model, Generic[AttributesT, ResourceLinksT, ResourceMetaT]):
     "A JSON API Resource"
+
     id: Union[str, uuid.UUID]
     attributes: AttributesT
     links: Optional[ResourceLinksT] = None
@@ -257,6 +258,7 @@ class Session(pydantic.BaseModel, **orm):
 
 class Principal(pydantic.BaseModel, **orm):
     "Represents a User or Service"
+
     # The id field (primary key) is intentionally not exposed to the application.
     # It is left as an internal database concern.
     uuid: uuid.UUID
@@ -280,6 +282,7 @@ class Principal(pydantic.BaseModel, **orm):
 
 class AllowedScopes(pydantic.BaseModel, **orm):
     "Returns roles and current allowed scopes for a user authenticated with API key or token"
+
     roles: List[str] = []
     scopes: List[str] = []
 

--- a/bluesky_httpserver/tests/conftest.py
+++ b/bluesky_httpserver/tests/conftest.py
@@ -4,6 +4,7 @@ import time as ttime
 import pytest
 import requests
 from bluesky_queueserver.manager.comms import zmq_single_request
+from bluesky_queueserver.manager.tests.common import set_qserver_zmq_encoding  # noqa: F401
 from xprocess import ProcessStarter
 
 import bluesky_httpserver.server as bqss
@@ -44,6 +45,8 @@ def fastapi_server_fs(xprocess):
 
     def start(http_server_host=SERVER_ADDRESS, http_server_port=SERVER_PORT, api_key=API_KEY_FOR_TESTS):
         class Starter(ProcessStarter):
+            max_read_lines = 53
+
             env = dict(os.environ)
             if api_key:
                 env["QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY"] = api_key

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
-    'matplotlib.sphinxext.plot_directive',
+    # 'matplotlib.sphinxext.plot_directive',
     'numpydoc',
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,7 @@ todo_include_todos = False
 html_theme = 'sphinx_rtd_theme'
 import sphinx_rtd_theme
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -100,6 +100,9 @@ The following environment variables are used to configure 0MQ communication sett
   pass the private key to RE Manager. Pass the public key to HTTP Server using
   ``QSERVER_ZMQ_PUBLIC_KEY`` environment variable.
 
+- ``QSERVER_ZMQ_ENCODING`` - sets the encoding for the messages set to RE Manager over
+  0MQ. Supported values: ``"json"`` (default) or ``"msgpack"``.
+
 The same parameters can be specified by including ``qserver_zmq_configuration`` into
 the config file::
 
@@ -107,6 +110,7 @@ the config file::
     control_address: tcp://localhost:60615
     info_address: tcp://localhost:60625
     public_key: ${PUBLIC_KEY}
+    encoding: json
 
 All parameters in the config file are optional and override the values passed using
 environment variables and the default values. The public key is typically passed using environment

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ py
 sphinx
 ipython
 numpydoc
+pandas
 sphinx
 sphinx_rtd_theme
 requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ py
 sphinx
 ipython
 numpydoc
+matplotlib
 pandas
 sphinx
 sphinx_rtd_theme

--- a/start_LDAP.sh
+++ b/start_LDAP.sh
@@ -4,5 +4,5 @@ set -e
 
 # Start LDAP server in docker container
 sudo docker pull bitnami/openldap:latest
-sudo docker-compose -f .github/workflows/docker-configs/ldap-docker-compose.yml up -d
+sudo docker compose -f .github/workflows/docker-configs/ldap-docker-compose.yml up -d
 sudo docker ps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add support for environment variable `QSERVER_ZMQ_ENCODING`, which sets encoding for 0MQ messages.

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Add support for `QSERVER_ZMQ_ENCODING` environment variable, which sets the encoding for 0MQ messages.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
