### PR TITLE
Add support for base_url parameter in ServerBasedAPIAccessControl

### DIFF
--- a/bluesky_httpserver/authorization/api_access.py
+++ b/bluesky_httpserver/authorization/api_access.py
@@ -469,10 +469,20 @@ properties:
     type: string
   roles:  # Detailed validation is performed elsewhere
     description: The value is passed to BasicAPIAccessControl object
-  server:
-    type: string
-  port:
-    type: integer
+  oneOf:
+    - properties:
+        base_url:
+          type: string
+      required:
+        - base_url
+    - properties:
+        server:
+          type: string
+        port:
+          type: integer
+      required:
+        - server
+        - port
   update_period:
     type: integer
   expiration_period:
@@ -528,11 +538,17 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
     roles: dict or None, optional
         The dictionary that defines new and/or modifies existing roles. The dictionary
         is passed to the ``BasicAPIAccessControl`` constructor. Default: ``None``.
+    base_url: str, optional
+        The base URL for the Access Control server, such as
+        ``'http://accesscontrol.server.com:8000'``. If provided, this parameter is used
+        instead of the `server` and `port` parameters.
     server: str, optional
         Access Control server address, such as ``'accesscontrol.server.com'`` or
-        ``'110.43.6.45'``. The default address is ``localhost``.
+        ``'110.43.6.45'``. This parameter is used only if `base_url` is not provided.
+        The default address is ``localhost``.
     port: int, optional
-        Access Control server port. The default port is `8000`.
+        Access Control server port. This parameter is used only if `base_url` is not
+        provided. The default port is `8000`.
     update_period: int, optional
         Average period in seconds between consecutive requests for updated access data.
         The actual period is randomized (uniform distribution in the range +/-20% of
@@ -552,6 +568,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         *,
         instrument=None,
         roles=None,
+        base_url=None,
         server="localhost",
         port=8000,
         update_period=600,
@@ -567,6 +584,7 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
             config = {
                 "instrument": instrument,
                 "roles": roles,
+                "base_url": base_url,
                 "server": server,
                 "port": port,
                 "update_period": update_period,
@@ -580,9 +598,11 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
             raise ConfigError(f"ValidationError while validating parameters BasicAPIAccessControl: {msg}") from err
 
         self._instrument = instrument.lower()
+        if base_url:
+            self._base_url = base_url
+        else:
+            self._base_url = f"http://{server}:{port}"
 
-        self._server = server
-        self._port = port
         self._update_period = update_period
         self._http_timeout = http_timeout
         self._expiration_period = expiration_period or (update_period * 1.5)
@@ -597,9 +617,8 @@ class ServerBasedAPIAccessControl(BasicAPIAccessControl):
         """
         Send a single request to the API server and update locally stored access control info.
         """
-        base_url = f"http://{self._server}:{self._port}"
         access_api = f"/instrument/{self._instrument.lower()}/qserver/access"
-        async with httpx.AsyncClient(base_url=base_url, timeout=self._http_timeout) as client:
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=self._http_timeout) as client:
             response = await client.get(access_api)
             response.raise_for_status()
             groups = response.json()


### PR DESCRIPTION
## Summary

Add support for `base_url` parameter to `ServerBasedAPIAccessControl` 

## Description

Added a `base_url` parameter to `ServerBasedAPIAccessControl` policy as an option to the current `server` + `port` parameters to generate the URL to query for authorization access. 

This change enables `https` requests and domain names that can rely on default http ports, i.e. :80 or :443, as well as services deployed under path parameters behind a reverse proxy, e.g. `https://myserver.example.com/access-api`.  

## Motivation and Context

I wanted to setup my `http-server` to query an external service for authorization and it was not able to request the server since the current generated `base_url` does not support full URLs, so it constructs the URL without `https` and without a required path parameter.

## Summary of Changes for Release Notes

### Added
- Add support for `base_url` parameter in `ServerBasedAPIAccessControl` policy.

## How Has This Been Tested?
Since it only changes a class property initialization, would appreciate some guidance on what a relevant test would be. Should I replicate the current policy testing only changing the init argument? 
