### PR TITLE
Create SingleGroupResourceAccessControl

### DIFF
--- a/bluesky_httpserver/authorization/__init__.py
+++ b/bluesky_httpserver/authorization/__init__.py
@@ -4,4 +4,4 @@ from .api_access import (  # noqa: F401
     DictionaryAPIAccessControl,
     ServerBasedAPIAccessControl,
 )
-from .resource_access import DefaultResourceAccessControl  # noqa: F401
+from .resource_access import DefaultResourceAccessControl, SingleGroupResourceAccessControl  # noqa: F401

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -123,6 +123,6 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
         """
         if isinstance(group, list):
             if group[-1] in ["unauthenticated_public", "unauthenticated_single_user"]:
-                return self.get_resource_group(username, group)
+                return self._default_group
             return group[-1]
         return group

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -61,7 +61,7 @@ class DefaultResourceAccessControl:
         default_group = default_group or _DEFAULT_RESOURCE_ACCESS_GROUP
         self._default_group = default_group
 
-    def get_resource_group(self, username):
+    def get_resource_group(self, username, group):
         """
         Returns the name of the user group based on the user name.
 
@@ -76,3 +76,54 @@ class DefaultResourceAccessControl:
             Name of the user group.
         """
         return self._default_group
+
+
+class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
+    """
+    Single group resource access policy.
+    The resource access policy associates users with its correspondent first user group. The groups
+    define the resources, such as plans and devices users can access. The
+    single group policy assumes that one user belong to a single group or if they are unauthenticated or 
+    have authenticated with a single-user API key, it uses the default user group.
+    The arguments of the class constructor are the same as the one specified in the DefaultResourceAccessControl configuration
+    file as shown in the example below.
+
+    Parameters
+    ----------
+    default_group: str
+        The name of the group returned by the access manager by default.
+
+    Examples
+    --------
+    Configure ``SingleGroupResourceAccessControl`` policy. The default group name is ``test_user``.
+
+    .. code-block::
+
+        resource_access:
+          policy: bluesky_httpserver.authorization:SingleGroupResourceAccessControl
+          args:
+            default_group: test_user
+    """
+
+    def get_resource_group(self, username, group):
+        """
+        Returns the name of the user group based on the user name.
+
+        Parameters
+        ----------
+        username: str
+            User name.
+
+        Returns
+        -------
+        str
+            Name of the user group.
+        """
+        if isinstance(group, list):
+            if group[0] in ['unauthenticated_public', 'unauthenticated_single_user']:
+                return self.get_resource_group(username, group)
+            return group[0]
+        return group
+
+
+

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -2,7 +2,7 @@ import jsonschema
 import yaml
 
 from ..config_schemas.loading import ConfigError
-from ._defaults import _DEFAULT_RESOURCE_ACCESS_GROUP
+from ._defaults import _DEFAULT_RESOURCE_ACCESS_GROUP, _DEFAULT_ROLE_PUBLIC, _DEFAULT_ROLE_SINGLE_USER
 
 _schema_DefaultResourceAccessControl = """
 $schema": http://json-schema.org/draft-07/schema#
@@ -122,7 +122,7 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
             Name of the user group.
         """
         if isinstance(group, list):
-            if group[-1] in ["unauthenticated_public", "unauthenticated_single_user"]:
+            if group[-1] in [_DEFAULT_ROLE_PUBLIC, _DEFAULT_ROLE_SINGLE_USER]:
                 return self._default_group
             return group[-1]
         return group

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -122,7 +122,7 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
             Name of the user group.
         """
         if isinstance(group, list):
-            if group[-1] in [_DEFAULT_ROLE_PUBLIC, _DEFAULT_ROLE_SINGLE_USER]:
-                return self._default_group
-            return group[-1]
+            group = group[-1]
+        if group in [_DEFAULT_ROLE_PUBLIC, _DEFAULT_ROLE_SINGLE_USER]:
+            return self._default_group
         return group

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -81,12 +81,12 @@ class DefaultResourceAccessControl:
 class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
     """
     Single group resource access policy.
-    The resource access policy associates users with its correspondent first user group. 
+    The resource access policy associates users with its correspondent first user group.
     The groups define the resources, such as plans and devices users can access. The
-    single group policy assumes that one user belong to a single group or if they are 
-    unauthenticated or have authenticated with a single-user API key, it uses the default 
+    single group policy assumes that one user belong to a single group or if they are
+    unauthenticated or have authenticated with a single-user API key, it uses the default
     user group.
-    The arguments of the class constructor are the same as the one specified in the 
+    The arguments of the class constructor are the same as the one specified in the
     DefaultResourceAccessControl configuration ile as shown in the example below.
 
     Parameters
@@ -96,7 +96,7 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
 
     Examples
     --------
-    Configure ``SingleGroupResourceAccessControl`` policy. The default group name is 
+    Configure ``SingleGroupResourceAccessControl`` policy. The default group name is
     ``test_user``.
 
     .. code-block::

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -122,7 +122,7 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
             Name of the user group.
         """
         if isinstance(group, list):
-            if group[0] in ["unauthenticated_public", "unauthenticated_single_user"]:
+            if group[-1] in ["unauthenticated_public", "unauthenticated_single_user"]:
                 return self.get_resource_group(username, group)
-            return group[0]
+            return group[-1]
         return group

--- a/bluesky_httpserver/authorization/resource_access.py
+++ b/bluesky_httpserver/authorization/resource_access.py
@@ -81,12 +81,13 @@ class DefaultResourceAccessControl:
 class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
     """
     Single group resource access policy.
-    The resource access policy associates users with its correspondent first user group. The groups
-    define the resources, such as plans and devices users can access. The
-    single group policy assumes that one user belong to a single group or if they are unauthenticated or 
-    have authenticated with a single-user API key, it uses the default user group.
-    The arguments of the class constructor are the same as the one specified in the DefaultResourceAccessControl configuration
-    file as shown in the example below.
+    The resource access policy associates users with its correspondent first user group. 
+    The groups define the resources, such as plans and devices users can access. The
+    single group policy assumes that one user belong to a single group or if they are 
+    unauthenticated or have authenticated with a single-user API key, it uses the default 
+    user group.
+    The arguments of the class constructor are the same as the one specified in the 
+    DefaultResourceAccessControl configuration ile as shown in the example below.
 
     Parameters
     ----------
@@ -95,7 +96,8 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
 
     Examples
     --------
-    Configure ``SingleGroupResourceAccessControl`` policy. The default group name is ``test_user``.
+    Configure ``SingleGroupResourceAccessControl`` policy. The default group name is 
+    ``test_user``.
 
     .. code-block::
 
@@ -120,10 +122,7 @@ class SingleGroupResourceAccessControl(DefaultResourceAccessControl):
             Name of the user group.
         """
         if isinstance(group, list):
-            if group[0] in ['unauthenticated_public', 'unauthenticated_single_user']:
+            if group[0] in ["unauthenticated_public", "unauthenticated_single_user"]:
                 return self.get_resource_group(username, group)
             return group[0]
         return group
-
-
-

--- a/bluesky_httpserver/routers/core_api.py
+++ b/bluesky_httpserver/routers/core_api.py
@@ -199,7 +199,7 @@ async def queue_item_add_handler(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
         displayed_name = api_access_manager.get_displayed_user_name(username)
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
         payload.update({"user": displayed_name, "user_group": user_group})
 
         if "item" not in payload:
@@ -228,7 +228,7 @@ async def queue_item_execute_handler(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
         displayed_name = api_access_manager.get_displayed_user_name(username)
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
         payload.update({"user": displayed_name, "user_group": user_group})
 
         if "item" not in payload:
@@ -257,7 +257,7 @@ async def queue_item_add_batch_handler(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
         displayed_name = api_access_manager.get_displayed_user_name(username)
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
         payload.update({"user": displayed_name, "user_group": user_group})
 
         if "items" not in payload:
@@ -330,7 +330,7 @@ async def queue_upload_spreadsheet(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
         displayed_name = api_access_manager.get_displayed_user_name(username)
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
 
         if custom_module:
             logger.info("Processing spreadsheet using function from external module ...")
@@ -399,7 +399,7 @@ async def queue_item_update_handler(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
         displayed_name = api_access_manager.get_displayed_user_name(username)
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
         payload.update({"user": displayed_name, "user_group": user_group})
 
         msg = await SR.RM.item_update(**payload)
@@ -731,7 +731,7 @@ async def plans_allowed_handler(
         username = get_current_username(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
 
         if "reduced" in payload:
             reduced = payload["reduced"]
@@ -763,7 +763,7 @@ async def devices_allowed_handler(
         username = get_current_username(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
 
         payload.update({"user_group": user_group})
 
@@ -878,7 +878,7 @@ async def function_execute_handler(
             principal=principal, settings=settings, api_access_manager=api_access_manager
         )[0]
         displayed_name = api_access_manager.get_displayed_user_name(username)
-        user_group = resource_access_manager.get_resource_group(username)
+        user_group = resource_access_manager.get_resource_group(username, principal.roles)
         payload.update({"user": displayed_name, "user_group": user_group})
 
         if "item" not in payload:

--- a/bluesky_httpserver/tests/test_access_policies.py
+++ b/bluesky_httpserver/tests/test_access_policies.py
@@ -546,7 +546,7 @@ def test_DefaultResourceAccessControl_01(params, group, success):
     """
     if success:
         manager = DefaultResourceAccessControl(**params)
-        assert manager.get_resource_group("arbitrary_user_name") == group
+        assert manager.get_resource_group("arbitrary_user_name", group) == group
     else:
         with pytest.raises(ConfigError):
             DefaultResourceAccessControl(**params)

--- a/bluesky_httpserver/tests/test_access_policies.py
+++ b/bluesky_httpserver/tests/test_access_policies.py
@@ -14,6 +14,7 @@ from bluesky_httpserver.authorization import (
     DefaultResourceAccessControl,
     DictionaryAPIAccessControl,
     ServerBasedAPIAccessControl,
+    SingleGroupResourceAccessControl,
 )
 from bluesky_httpserver.authorization._defaults import (
     _DEFAULT_RESOURCE_ACCESS_GROUP,
@@ -550,3 +551,23 @@ def test_DefaultResourceAccessControl_01(params, group, success):
     else:
         with pytest.raises(ConfigError):
             DefaultResourceAccessControl(**params)
+
+
+# fmt: off
+@pytest.mark.parametrize("params, role, group, success", [
+    ({"default_group": "expert"}, [_DEFAULT_ROLE_PUBLIC], "expert", True),
+    ({"default_group": "user"}, _DEFAULT_ROLE_SINGLE_USER, "user", True),
+    ({"default_group": "user"}, _DEFAULT_ROLE_SINGLE_USER, _DEFAULT_ROLE_SINGLE_USER, False),
+    ({"default_group": "user"}, ["expert"], "expert", True),
+    ({"default_group": "user"}, "advanced", "advanced", True),
+    ({"default_group": "user"}, "advanced", "user", False),
+])
+# fmt: on
+def test_SingleGroupResourceAccessControl_01(params, role, group, success):
+    """
+    SingleGroupResourceAccessControl: basic tests.
+    """
+    manager = SingleGroupResourceAccessControl(**params)
+    result = manager.get_resource_group("arbitrary_user_name", role) == group
+    print(manager.get_resource_group("arbitrary_user_name", role))
+    assert result == success

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -457,7 +457,6 @@ is passed to Run Engine Manager in some API calls.
 Default Resource Access Policy
 ++++++++++++++++++++++++++++++
 
-Only the default policy ``DefaultResourceAccessControl`` is currently implemented.
 This is a simple policy, which associates one fixed group name with all users.
 The group name used by default is ``'primary'``. ``DefaultResourceAccessControl``
 with default settings is activated by default if no other policy is selected
@@ -482,3 +481,31 @@ See the documentation on ``DefaultResourceAccessControl`` for more details.
    :toctree: generated
 
     authorization.DefaultResourceAccessControl
+
+
+Single Group Resource Access Policy
++++++++++++++++++++++++++++++++++++
+
+This is a policy that associates one group name with one user, based on the
+specified user group in the access policy.
+The default group name is defined in the same way as the
+``DefaultResourceAccessControl``.
+This functionality can be very useful in order to provide different levels
+of access to different users directly in the server so all the clients
+can receive the same plans and devices for a specific user.
+
+The default group name can be changed in the policy configuration. For example,
+the following policy configuration sets the returned group name to ``test_user``::
+
+    resource_access:
+      policy: bluesky_httpserver.authorization:SingleGroupResourceAccessControl
+      args:
+        default_group: test_user
+
+See the documentation on ``SingleGroupResourceAccessControl`` for more details.
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+    authorization.SingleGroupResourceAccessControl


### PR DESCRIPTION
This resource access control returns the first user group setted to the current user on the API access policy.
Configuration file example in which the user1 will have access to 'user' group plans and devices and user2 will have access to 'expert' group plans and devices:
```
api_access:
  policy: bluesky_httpserver.authorization:DictionaryAPIAccessControl
  args:
    users:
      user1:
        roles:
          - user
       user2:
        roles:
          - expert
          - admin
resource_access:
  policy: bluesky_httpserver.authorization:SingleGroupResourceAccessControl
  args:
    default_group: root
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Allow different users to have access to different plans depending on their specific uses. This is mainly intended to give a broader range of plans and devices for the beamline staff while hiding most of the auxiliary plans from the beamline users.

## Summary of Changes for Release Notes
Added the SingleGroupResourceAccessControl class for resource control.

<!--- Group the changes in the following sections: -->

### Added

A new resource access mode, for showing only the logged user allowed resources by its first setted group in the api access policy.

## How Has This Been Tested?
This was tested initially with a GUI that uses the bluesky_widgets library to communicate with a local HTTP server instance, with a DictionaryAuthenticator as authenticator and a DictionaryAPIAccessControl as api_access. This test included anonymous access users to interact with the GUI.
Further tests using LDAPAuthenticator as authenticator and ServerBasedAPIAccessControl as api_access will still be conducted.
